### PR TITLE
TST: Fix test failures on Python 3.7

### DIFF
--- a/linearmodels/iv/data.py
+++ b/linearmodels/iv/data.py
@@ -175,6 +175,7 @@ class IVData(object):
         return np.any(self._pandas.isnull(), axis=1)
 
     def drop(self, locs):
+        locs = np.asarray(locs)
         self._pandas = self.pandas.loc[~locs]
         self._ndarray = self._ndarray[~locs]
         self._labels[0] = list(pd.Series(self._labels[0]).loc[~locs])

--- a/linearmodels/tests/panel/test_panel_ols.py
+++ b/linearmodels/tests/panel/test_panel_ols.py
@@ -25,7 +25,7 @@ ids = list(map(lambda s: '-'.join(map(str, s)), perms))
 @pytest.fixture(params=perms, ids=ids)
 def data(request):
     missing, datatype, const = request.param
-    return generate_data(missing, datatype, const=const, ntk=(91, 7, 5), other_effects=2)
+    return generate_data(missing, datatype, const=const, ntk=(91, 15, 5), other_effects=2)
 
 
 @pytest.fixture(params=perms, ids=ids)


### PR DESCRIPTION
Test failures due to incorect simulation design
Ensure dropping strips indices