### PR TITLE
BUG: Fix rank checks in linear asset pricing models

### DIFF
--- a/linearmodels/asset_pricing/model.py
+++ b/linearmodels/asset_pricing/model.py
@@ -99,13 +99,16 @@ class TradedFactorModel(object):
         p = self.portfolios.ndarray
         f = self.factors.ndarray
         if has_constant(p)[0]:
-            raise ValueError('portfolios must not contains a constant or equivalent.')
+            raise ValueError('portfolios must not contains a constant or '
+                             'equivalent and must not have rank\n'
+                             'less than the dimension of the smaller shape.')
         if has_constant(f)[0]:
             raise ValueError('factors must not contain a constant or equivalent.')
         if np.linalg.matrix_rank(f) < f.shape[1]:
             raise ValueError('Model cannot be estimated. factors do not have full column rank.')
-        if np.linalg.matrix_rank(p) < p.shape[1]:
-            raise ValueError('Model cannot be estimated. portfolios do not have full column rank.')
+        if p.shape[0] < (f.shape[1] + 1):
+            raise ValueError('Model cannot be estimated. portfolios must have factors + 1 or '
+                             'more returns to\nestimate the model parameters.')
 
     @property
     def formula(self):

--- a/linearmodels/tests/asset_pricing/test_linear_factor_model.py
+++ b/linearmodels/tests/asset_pricing/test_linear_factor_model.py
@@ -314,3 +314,10 @@ def test_linear_model_parameters_risk_free_gls(data):
     assert_allclose(res.j_statistic.pval, 1 - stats.chi2(nport - nf - 1).cdf(jstat), rtol=1e-2)
 
     get_all(res)
+
+
+@pytest.mark.parametrize('output', ['numpy', 'pandas'])
+def test_infeasible(output):
+    data = generate_data(nfactor=10, nportfolio=20, nobs=10, output=output)
+    with pytest.raises(ValueError):
+        LinearFactorModel(data.portfolios, data.factors)

--- a/linearmodels/tests/test_utility.py
+++ b/linearmodels/tests/test_utility.py
@@ -39,7 +39,7 @@ def test_missing_warning():
 def test_hasconstant():
     x = np.random.randn(100, 3)
     hc, loc = has_constant(x)
-    assert hc is False
+    assert bool(hc) is False
     assert loc is None
     x[:, 0] = 1
     hc, loc = has_constant(x)

--- a/linearmodels/utility.py
+++ b/linearmodels/utility.py
@@ -144,13 +144,14 @@ def has_constant(x, x_rank=None):
     aug_rank = np.linalg.matrix_rank(np.c_[np.ones((n, 1)), x])
     rank = np.linalg.matrix_rank(x) if x_rank is None else x_rank
 
-    has_const = bool(aug_rank == rank)
+    has_const = (aug_rank == rank) and x.shape[0] > x.shape[1]
+    has_const = has_const or rank < min(x.shape)
     loc = None
     if has_const:
         out = lstsq(x, np.ones((n, 1)))
         beta = out[0].ravel()
         loc = np.argmax(np.abs(beta) * x.var(0))
-    return has_const, loc
+    return bool(has_const), loc
 
 
 def inv_sqrth(x):


### PR DESCRIPTION
Fix has_constant to work with fewer observations and columns
Change dimension checks to reflect actual requirements