### PR TITLE
Include LICENSE.md in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ recursive-include linearmodels/datasets *
 recursive-include examples *
 include versioneer.py
 include linearmodels/_version.py
+include LICENSE.md
 include README.md
 include requirements.txt
 include requirements-dev.txt


### PR DESCRIPTION
I was attempting to add this to conda-forge as it will help some folks who use conda, and realized that the tarball on pypi doesn't come with LICENSE.md packaged (as required by conda-forge). Added to the MANIFEST to make sure it gets added.