### PR TITLE
fixed ac nobs overwrite

### DIFF
--- a/linearmodels/panel/covariance.py
+++ b/linearmodels/panel/covariance.py
@@ -554,10 +554,10 @@ class ACCovariance(HomoskedasticCovariance):
         eps = self.eps
         assert self._time_ids is not None
         time_ids = np.unique(self._time_ids.squeeze())
-        nobs = len(time_ids)
+        nperiods = len(time_ids)
         bw = self._bandwidth
         if self._bandwidth is None:
-            bw = float(np.floor(4 * (nobs / 100) ** (2 / 9)))
+            bw = float(np.floor(4 * (nperiods / 100) ** (2 / 9)))
         assert bw is not None
 
         xe = x * eps


### PR DESCRIPTION
nobs is being overwritten on line 557 where it originally refers to T x N and was changed to T only. Results in exaggerated standard errors since line 580 refers to the new nobs (T) variable where in reality it should refer to line 552, or T x N.