### PR TITLE
ENH: add misspecificatin robust inference for GMM models enhancement

### DIFF
--- a/linearmodels/iv/covariance.py
+++ b/linearmodels/iv/covariance.py
@@ -7,27 +7,13 @@ from __future__ import annotations
 from typing import Any, Callable, Dict, Optional, Union, cast
 
 from mypy_extensions import VarArg
-from numpy import (
-    arange,
-    asarray,
-    ceil,
-    cos,
-    empty,
-    int64,
-    ndarray,
-    ones,
-    pi,
-    sin,
-    sum as npsum,
-    unique,
-    zeros,
-    diagflat,
-    kron,
-)
+from numpy import (arange, asarray, ceil, cos, diagflat, empty, int64, kron,
+                   ndarray, ones, pi, sin, sum as npsum, unique, zeros)
 from numpy.linalg import inv, pinv
 
 from linearmodels.shared.covariance import cov_cluster, cov_kernel
-from linearmodels.typing import AnyArray, Float64Array, Numeric, OptionalNumeric
+from linearmodels.typing import (AnyArray, Float64Array, Numeric,
+                                 OptionalNumeric)
 
 KernelWeight = Union[
     Callable[[float, float], ndarray],
@@ -132,7 +118,7 @@ def kernel_weight_parzen(bw: float, *args: int) -> Float64Array:
        w_i &  = 2(1-z_i)^3, z > 0.5
     """
     z = arange(int(bw) + 1) / (int(bw) + 1)
-    w = 1 - 6 * z ** 2 + 6 * z ** 3
+    w = 1 - 6 * z**2 + 6 * z**3
     w[z > 0.5] = 2 * (1 - z[z > 0.5]) ** 3
     return w
 
@@ -189,7 +175,7 @@ def kernel_optimal_bandwidth(x: Float64Array, kernel: str = "bartlett") -> int:
     sq = 2 * npsum(sigma[1:] * arange(1, m_star + 1) ** q)
     rate = 1 / (2 * q + 1)
     gamma = c * ((sq / s0) ** 2) ** rate
-    m = gamma * t ** rate
+    m = gamma * t**rate
     return min(int(ceil(m)), t - 1)
 
 
@@ -250,14 +236,14 @@ class HomoskedasticCovariance(object):
     """
 
     def __init__(
-            self,
-            x: Float64Array,
-            y: Float64Array,
-            z: Float64Array,
-            params: Float64Array,
-            debiased: bool = False,
-            kappa: Numeric = 1,
-            w: Float64Array = zeros(1),
+        self,
+        x: Float64Array,
+        y: Float64Array,
+        z: Float64Array,
+        params: Float64Array,
+        debiased: bool = False,
+        kappa: Numeric = 1,
+        w: Float64Array = zeros(1),
     ):
         if not (x.shape[0] == y.shape[0] == z.shape[0]):
             raise ValueError("x, y and z must have the same number of rows")
@@ -286,10 +272,10 @@ class HomoskedasticCovariance(object):
 
     def __repr__(self) -> str:
         return (
-                self.__str__()
-                + "\n"
-                + self.__class__.__name__
-                + ", id: {0}".format(hex(id(self)))
+            self.__str__()
+            + "\n"
+            + self.__class__.__name__
+            + ", id: {0}".format(hex(id(self)))
         )
 
     @property
@@ -391,13 +377,13 @@ class HeteroskedasticCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-            self,
-            x: Float64Array,
-            y: Float64Array,
-            z: Float64Array,
-            params: Float64Array,
-            debiased: bool = False,
-            kappa: Numeric = 1,
+        self,
+        x: Float64Array,
+        y: Float64Array,
+        z: Float64Array,
+        params: Float64Array,
+        debiased: bool = False,
+        kappa: Numeric = 1,
     ):
         super(HeteroskedasticCovariance, self).__init__(
             x, y, z, params, debiased, kappa
@@ -484,15 +470,15 @@ class KernelCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-            self,
-            x: Float64Array,
-            y: Float64Array,
-            z: Float64Array,
-            params: Float64Array,
-            kernel: str = "bartlett",
-            bandwidth: OptionalNumeric = None,
-            debiased: bool = False,
-            kappa: Numeric = 1,
+        self,
+        x: Float64Array,
+        y: Float64Array,
+        z: Float64Array,
+        params: Float64Array,
+        kernel: str = "bartlett",
+        bandwidth: OptionalNumeric = None,
+        debiased: bool = False,
+        kappa: Numeric = 1,
     ):
         super(KernelCovariance, self).__init__(x, y, z, params, debiased, kappa)
         self._kernels = KERNEL_LOOKUP
@@ -604,14 +590,14 @@ class ClusteredCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-            self,
-            x: Float64Array,
-            y: Float64Array,
-            z: Float64Array,
-            params: Float64Array,
-            clusters: Optional[AnyArray] = None,
-            debiased: bool = False,
-            kappa: Numeric = 1,
+        self,
+        x: Float64Array,
+        y: Float64Array,
+        z: Float64Array,
+        params: Float64Array,
+        clusters: Optional[AnyArray] = None,
+        debiased: bool = False,
+        kappa: Numeric = 1,
     ):
         super(ClusteredCovariance, self).__init__(x, y, z, params, debiased, kappa)
 
@@ -736,15 +722,15 @@ class MisspecificationCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-            self,
-            x: Float64Array,
-            y: Float64Array,
-            z: Float64Array,
-            params: Float64Array,
-            clusters: Optional[AnyArray] = None,
-            debiased: bool = False,
-            kappa: Numeric = 1,
-            w: Float64Array = zeros(1),
+        self,
+        x: Float64Array,
+        y: Float64Array,
+        z: Float64Array,
+        params: Float64Array,
+        clusters: Optional[AnyArray] = None,
+        debiased: bool = False,
+        kappa: Numeric = 1,
+        w: Float64Array = zeros(1),
     ):
         super(MisspecificationCovariance, self).__init__(
             x, y, z, params, debiased, kappa, w
@@ -810,9 +796,7 @@ class MisspecificationCovariance(HomoskedasticCovariance):
         eTz = eps.T @ self.z
         zTx = self.z.T @ self.x
         xTz = self.x.T @ self.z
-        idx = repmat(mem, 1, G).T == kron(
-            ones((nobs, 1)), unique(mem).reshape(1, -1)
-        )
+        idx = repmat(mem, 1, G).T == kron(ones((nobs, 1)), unique(mem).reshape(1, -1))
         for g in range(G):
             zg = self.z[idx[:, g], :]
             eg = eps[idx[:, g]]
@@ -821,15 +805,15 @@ class MisspecificationCovariance(HomoskedasticCovariance):
             zgTxg = zg.T @ xg
 
             Hpart = (
-                    Hpart + zgTeg @ eTz @ invw @ zgTxg + zgTxg * (eTz @ invw @ zgTeg)[0][0]
+                Hpart + zgTeg @ eTz @ invw @ zgTxg + zgTxg * (eTz @ invw @ zgTeg)[0][0]
             )
             Psi[g, :] = (
-                    -(1 / nobs) * xTz @ invw @ zgTeg
-                    - (1 / nobs) * (xg.T @ zg) @ invw @ zTe
-                    + (1 / nobs ** 2) * xTz @ invw @ zgTeg @ (eg.T @ zg) @ invw @ zTe
+                -(1 / nobs) * xTz @ invw @ zgTeg
+                - (1 / nobs) * (xg.T @ zg) @ invw @ zTe
+                + (1 / nobs**2) * xTz @ invw @ zgTeg @ (eg.T @ zg) @ invw @ zTe
             ).T
 
-        H = (1 / nobs ** 2) * xTz @ invw @ zTx - (1 / nobs ** 3) * xTz @ invw @ Hpart
+        H = (1 / nobs**2) * xTz @ invw @ zTx - (1 / nobs**3) * xTz @ invw @ Hpart
 
         Om = (Psi.T @ Psi) / nobs
 
@@ -869,14 +853,14 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-            self,
-            x: Float64Array,
-            y: Float64Array,
-            z: Float64Array,
-            params: Float64Array,
-            clusters: Optional[AnyArray] = None,
-            debiased: bool = False,
-            kappa: Numeric = 1,
+        self,
+        x: Float64Array,
+        y: Float64Array,
+        z: Float64Array,
+        params: Float64Array,
+        clusters: Optional[AnyArray] = None,
+        debiased: bool = False,
+        kappa: Numeric = 1,
     ):
         super(OneStepMisspecificationCovariance, self).__init__(
             x, y, z, params, debiased, kappa
@@ -938,7 +922,7 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
         wmat = zeros((z_num, z_num))
         W0i = zeros((z_num, z_num, G))
         for i in range(G):
-            Zi = self.z[int(sum(ng[0: i + 1]) - ng[i]): int(sum(ng[0: i + 1])), :]
+            Zi = self.z[int(sum(ng[0 : i + 1]) - ng[i]) : int(sum(ng[0 : i + 1])), :]
 
             h0 = 2 * ones((int(ng[i]), 1))
             h1 = -1 * ones((int(ng[i]) - 1, 1))
@@ -951,12 +935,12 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
         mu1 = (self.z.T @ eps) / nobs
         Q = -(self.z.T @ self.x) / nobs
         for i in range(G):
-            Zi = self.z[int(sum(ng[: i + 1]) - ng[i]): int(sum(ng[: i + 1])), :]
-            e1i = eps[int(sum(ng[: i + 1]) - ng[i]): int(sum(ng[: i + 1]))]
-            DXi = self.x[int(sum(ng[: i + 1]) - ng[i]): int(sum(ng[: i + 1])), :]
+            Zi = self.z[int(sum(ng[: i + 1]) - ng[i]) : int(sum(ng[: i + 1])), :]
+            e1i = eps[int(sum(ng[: i + 1]) - ng[i]) : int(sum(ng[: i + 1]))]
+            DXi = self.x[int(sum(ng[: i + 1]) - ng[i]) : int(sum(ng[: i + 1])), :]
             psi_temp = Q.T @ inv(wmat) @ W0i[:, :, i] @ inv(wmat) @ mu1
             psi1 = (
-                    Q.T @ inv(wmat) @ Zi.T @ e1i - DXi.T @ Zi @ inv(wmat) @ mu1 - psi_temp
+                Q.T @ inv(wmat) @ Zi.T @ e1i - DXi.T @ Zi @ inv(wmat) @ mu1 - psi_temp
             )
             Om1 += psi1 @ psi1.T
         Om1 /= nobs

--- a/linearmodels/iv/covariance.py
+++ b/linearmodels/iv/covariance.py
@@ -7,27 +7,13 @@ from __future__ import annotations
 from typing import Any, Callable, Dict, Optional, Union, cast
 
 from mypy_extensions import VarArg
-from numpy import (
-    sum as npsum,
-    arange,
-    asarray,
-    ceil,
-    cos,
-    empty,
-    int64,
-    ndarray,
-    ones,
-    pi,
-    sin,
-    unique,
-    zeros,
-    diagflat,
-    kron,
-)
+from numpy import (arange, asarray, ceil, cos, diagflat, empty, int64, kron,
+                   ndarray, ones, pi, sin, sum as npsum, unique, zeros)
 from numpy.linalg import inv, pinv
 
 from linearmodels.shared.covariance import cov_cluster, cov_kernel
-from linearmodels.typing import AnyArray, Float64Array, Numeric, OptionalNumeric
+from linearmodels.typing import (AnyArray, Float64Array, Numeric,
+                                 OptionalNumeric)
 
 KernelWeight = Union[
     Callable[[float, float], ndarray],
@@ -132,7 +118,7 @@ def kernel_weight_parzen(bw: float, *args: int) -> Float64Array:
        w_i &  = 2(1-z_i)^3, z > 0.5
     """
     z = arange(int(bw) + 1) / (int(bw) + 1)
-    w = 1 - 6 * z ** 2 + 6 * z ** 3
+    w = 1 - 6 * z**2 + 6 * z**3
     w[z > 0.5] = 2 * (1 - z[z > 0.5]) ** 3
     return w
 
@@ -189,7 +175,7 @@ def kernel_optimal_bandwidth(x: Float64Array, kernel: str = "bartlett") -> int:
     sq = 2 * npsum(sigma[1:] * arange(1, m_star + 1) ** q)
     rate = 1 / (2 * q + 1)
     gamma = c * ((sq / s0) ** 2) ** rate
-    m = gamma * t ** rate
+    m = gamma * t**rate
     return min(int(ceil(m)), t - 1)
 
 
@@ -249,14 +235,14 @@ class HomoskedasticCovariance(object):
     """
 
     def __init__(
-            self,
-            x: Float64Array,
-            y: Float64Array,
-            z: Float64Array,
-            params: Float64Array,
-            debiased: bool = False,
-            kappa: Numeric = 1,
-            w: Float64Array = zeros(1)
+        self,
+        x: Float64Array,
+        y: Float64Array,
+        z: Float64Array,
+        params: Float64Array,
+        debiased: bool = False,
+        kappa: Numeric = 1,
+        w: Float64Array = zeros(1),
     ):
         if not (x.shape[0] == y.shape[0] == z.shape[0]):
             raise ValueError("x, y and z must have the same number of rows")
@@ -284,8 +270,12 @@ class HomoskedasticCovariance(object):
         return out
 
     def __repr__(self) -> str:
-        return (self.__str__() + "\n" + self.__class__.__name__ + ", id: {0}".
-                format(hex(id(self))))
+        return (
+            self.__str__()
+            + "\n"
+            + self.__class__.__name__
+            + ", id: {0}".format(hex(id(self)))
+        )
 
     @property
     def s(self) -> Float64Array:
@@ -386,13 +376,13 @@ class HeteroskedasticCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-            self,
-            x: Float64Array,
-            y: Float64Array,
-            z: Float64Array,
-            params: Float64Array,
-            debiased: bool = False,
-            kappa: Numeric = 1,
+        self,
+        x: Float64Array,
+        y: Float64Array,
+        z: Float64Array,
+        params: Float64Array,
+        debiased: bool = False,
+        kappa: Numeric = 1,
     ):
         super(HeteroskedasticCovariance, self).__init__(
             x, y, z, params, debiased, kappa
@@ -479,15 +469,15 @@ class KernelCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-            self,
-            x: Float64Array,
-            y: Float64Array,
-            z: Float64Array,
-            params: Float64Array,
-            kernel: str = "bartlett",
-            bandwidth: OptionalNumeric = None,
-            debiased: bool = False,
-            kappa: Numeric = 1,
+        self,
+        x: Float64Array,
+        y: Float64Array,
+        z: Float64Array,
+        params: Float64Array,
+        kernel: str = "bartlett",
+        bandwidth: OptionalNumeric = None,
+        debiased: bool = False,
+        kappa: Numeric = 1,
     ):
         super(KernelCovariance, self).__init__(x, y, z, params, debiased, kappa)
         self._kernels = KERNEL_LOOKUP
@@ -599,14 +589,14 @@ class ClusteredCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-            self,
-            x: Float64Array,
-            y: Float64Array,
-            z: Float64Array,
-            params: Float64Array,
-            clusters: Optional[AnyArray] = None,
-            debiased: bool = False,
-            kappa: Numeric = 1,
+        self,
+        x: Float64Array,
+        y: Float64Array,
+        z: Float64Array,
+        params: Float64Array,
+        clusters: Optional[AnyArray] = None,
+        debiased: bool = False,
+        kappa: Numeric = 1,
     ):
         super(ClusteredCovariance, self).__init__(x, y, z, params, debiased, kappa)
 
@@ -731,17 +721,19 @@ class MisspecificationCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-            self,
-            x: Float64Array,
-            y: Float64Array,
-            z: Float64Array,
-            params: Float64Array,
-            clusters: Optional[AnyArray] = None,
-            debiased: bool = False,
-            kappa: Numeric = 1,
-            w: Float64Array = zeros(1),
+        self,
+        x: Float64Array,
+        y: Float64Array,
+        z: Float64Array,
+        params: Float64Array,
+        clusters: Optional[AnyArray] = None,
+        debiased: bool = False,
+        kappa: Numeric = 1,
+        w: Float64Array = zeros(1),
     ):
-        super(MisspecificationCovariance, self).__init__(x, y, z, params, debiased, kappa, w)
+        super(MisspecificationCovariance, self).__init__(
+            x, y, z, params, debiased, kappa, w
+        )
 
         nobs = x.shape[0]
         clusters = arange(nobs) if clusters is None else clusters
@@ -769,10 +761,7 @@ class MisspecificationCovariance(HomoskedasticCovariance):
 
     @property
     def s(self) -> Float64Array:
-
-        def repmat(
-                self, a: Float64Array, b: int, c: int
-        ) -> Float64Array:
+        def repmat(self, a: Float64Array, b: int, c: int) -> Float64Array:
             """
             Parameters
             ----------
@@ -789,7 +778,7 @@ class MisspecificationCovariance(HomoskedasticCovariance):
 
         nobs, nvar = self.x.shape
         eps = self.y - self.x @ self.params
-        clusters = self.config['clusters']
+        clusters = self.config["clusters"]
         if clusters.shape[0] != nobs:
             raise ValueError(
                 "clusters has the wrong nobs. Expected {0}, "
@@ -806,7 +795,9 @@ class MisspecificationCovariance(HomoskedasticCovariance):
         eTz = eps.T @ self.z
         zTx = self.z.T @ self.x
         xTz = self.x.T @ self.z
-        idx = repmat(self, mem, 1, G).T == kron(ones((nobs, 1)), unique(mem).reshape(1, -1))
+        idx = repmat(self, mem, 1, G).T == kron(
+            ones((nobs, 1)), unique(mem).reshape(1, -1)
+        )
         for g in range(G):
             zg = self.z[idx[:, g], :]
             eg = eps[idx[:, g]]
@@ -814,12 +805,16 @@ class MisspecificationCovariance(HomoskedasticCovariance):
             zgTeg = zg.T @ eg
             zgTxg = zg.T @ xg
 
-            Hpart = Hpart + zgTeg @ eTz @ invw @ zgTxg + zgTxg * (eTz @ invw @ zgTeg)[0][0]
-            Psi[g, :] = (-(1 / nobs) * xTz @ invw @ zgTeg
-                         - (1 / nobs) * (xg.T @ zg) @ invw @ zTe
-                         + (1 / nobs ** 2) * xTz @ invw @ zgTeg @ (eg.T @ zg) @ invw @ zTe).T
+            Hpart = (
+                Hpart + zgTeg @ eTz @ invw @ zgTxg + zgTxg * (eTz @ invw @ zgTeg)[0][0]
+            )
+            Psi[g, :] = (
+                -(1 / nobs) * xTz @ invw @ zgTeg
+                - (1 / nobs) * (xg.T @ zg) @ invw @ zTe
+                + (1 / nobs**2) * xTz @ invw @ zgTeg @ (eg.T @ zg) @ invw @ zTe
+            ).T
 
-        H = (1 / nobs ** 2) * xTz @ invw @ zTx - (1 / nobs ** 3) * xTz @ invw @ Hpart
+        H = (1 / nobs**2) * xTz @ invw @ zTx - (1 / nobs**3) * xTz @ invw @ Hpart
 
         Om = (Psi.T @ Psi) / nobs
 
@@ -859,16 +854,18 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-            self,
-            x: Float64Array,
-            y: Float64Array,
-            z: Float64Array,
-            params: Float64Array,
-            clusters: Optional[AnyArray] = None,
-            debiased: bool = False,
-            kappa: Numeric = 1,
+        self,
+        x: Float64Array,
+        y: Float64Array,
+        z: Float64Array,
+        params: Float64Array,
+        clusters: Optional[AnyArray] = None,
+        debiased: bool = False,
+        kappa: Numeric = 1,
     ):
-        super(OneStepMisspecificationCovariance, self).__init__(x, y, z, params, debiased, kappa)
+        super(OneStepMisspecificationCovariance, self).__init__(
+            x, y, z, params, debiased, kappa
+        )
 
         nobs = x.shape[0]
         clusters = arange(nobs) if clusters is None else clusters
@@ -896,7 +893,6 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
 
     @property
     def s(self) -> Float64Array:
-
         def conutnum(x: Float64Array, binranges: Float64Array) -> Float64Array:
             """Bin counting for histograms, equal to MATLAB fun:histc."""
             temp = zeros((len(binranges), 2))
@@ -912,7 +908,7 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
 
         nobs, nvar = self.x.shape
         eps = self.y - self.x @ self.params
-        clusters = self.config['clusters']
+        clusters = self.config["clusters"]
         if clusters.shape[0] != nobs:
             raise ValueError(
                 "clusters has the wrong nobs. Expected {0}, "
@@ -927,7 +923,7 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
         wmat = zeros((z_num, z_num))
         W0i = zeros((z_num, z_num, G))
         for i in range(G):
-            Zi = self.z[int(sum(ng[0:i + 1]) - ng[i]): int(sum(ng[0:i + 1])), :]
+            Zi = self.z[int(sum(ng[0 : i + 1]) - ng[i]) : int(sum(ng[0 : i + 1])), :]
 
             h0 = 2 * ones((int(ng[i]), 1))
             h1 = -1 * ones((int(ng[i]) - 1, 1))
@@ -940,11 +936,13 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
         mu1 = (self.z.T @ eps) / nobs
         Q = -(self.z.T @ self.x) / nobs
         for i in range(G):
-            Zi = self.z[int(sum(ng[:i + 1]) - ng[i]): int(sum(ng[:i + 1])), :]
-            e1i = eps[int(sum(ng[:i + 1]) - ng[i]): int(sum(ng[:i + 1]))]
-            DXi = self.x[int(sum(ng[:i + 1]) - ng[i]): int(sum(ng[:i + 1])), :]
+            Zi = self.z[int(sum(ng[: i + 1]) - ng[i]) : int(sum(ng[: i + 1])), :]
+            e1i = eps[int(sum(ng[: i + 1]) - ng[i]) : int(sum(ng[: i + 1]))]
+            DXi = self.x[int(sum(ng[: i + 1]) - ng[i]) : int(sum(ng[: i + 1])), :]
             psi_temp = Q.T @ inv(wmat) @ W0i[:, :, i] @ inv(wmat) @ mu1
-            psi1 = Q.T @ inv(wmat) @ Zi.T @ e1i - DXi.T @ Zi @ inv(wmat) @ mu1 - psi_temp
+            psi1 = (
+                Q.T @ inv(wmat) @ Zi.T @ e1i - DXi.T @ Zi @ inv(wmat) @ mu1 - psi_temp
+            )
             Om1 += psi1 @ psi1.T
         Om1 /= nobs
         H0 = Q.T @ inv(wmat) @ Q

--- a/linearmodels/iv/covariance.py
+++ b/linearmodels/iv/covariance.py
@@ -766,8 +766,8 @@ class MisspecificationCovariance(HomoskedasticCovariance):
             Parameters
             ----------
             a : ndarray
-            b : ndarray
-            c : ndarray
+            b : int
+            c : int
 
             Returns
             -------

--- a/linearmodels/iv/covariance.py
+++ b/linearmodels/iv/covariance.py
@@ -22,7 +22,7 @@ from numpy import (
     unique,
     zeros,
     diagflat,
-    kron
+    kron,
 )
 from numpy.linalg import inv, pinv
 
@@ -132,7 +132,7 @@ def kernel_weight_parzen(bw: float, *args: int) -> Float64Array:
        w_i &  = 2(1-z_i)^3, z > 0.5
     """
     z = arange(int(bw) + 1) / (int(bw) + 1)
-    w = 1 - 6 * z**2 + 6 * z**3
+    w = 1 - 6 * z ** 2 + 6 * z ** 3
     w[z > 0.5] = 2 * (1 - z[z > 0.5]) ** 3
     return w
 
@@ -189,7 +189,7 @@ def kernel_optimal_bandwidth(x: Float64Array, kernel: str = "bartlett") -> int:
     sq = 2 * npsum(sigma[1:] * arange(1, m_star + 1) ** q)
     rate = 1 / (2 * q + 1)
     gamma = c * ((sq / s0) ** 2) ** rate
-    m = gamma * t**rate
+    m = gamma * t ** rate
     return min(int(ceil(m)), t - 1)
 
 
@@ -249,14 +249,14 @@ class HomoskedasticCovariance(object):
     """
 
     def __init__(
-        self,
-        x: Float64Array,
-        y: Float64Array,
-        z: Float64Array,
-        params: Float64Array,
-        debiased: bool = False,
-        kappa: Numeric = 1,
-        w: Float64Array = zeros(1)
+            self,
+            x: Float64Array,
+            y: Float64Array,
+            z: Float64Array,
+            params: Float64Array,
+            debiased: bool = False,
+            kappa: Numeric = 1,
+            w: Float64Array = zeros(1)
     ):
         if not (x.shape[0] == y.shape[0] == z.shape[0]):
             raise ValueError("x, y and z must have the same number of rows")
@@ -285,10 +285,10 @@ class HomoskedasticCovariance(object):
 
     def __repr__(self) -> str:
         return (
-            self.__str__()
-            + "\n"
-            + self.__class__.__name__
-            + ", id: {0}".format(hex(id(self)))
+                self.__str__()
+                + "\n"
+                + self.__class__.__name__
+                + ", id: {0}".format(hex(id(self)))
         )
 
     @property
@@ -390,13 +390,13 @@ class HeteroskedasticCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-        self,
-        x: Float64Array,
-        y: Float64Array,
-        z: Float64Array,
-        params: Float64Array,
-        debiased: bool = False,
-        kappa: Numeric = 1,
+            self,
+            x: Float64Array,
+            y: Float64Array,
+            z: Float64Array,
+            params: Float64Array,
+            debiased: bool = False,
+            kappa: Numeric = 1,
     ):
         super(HeteroskedasticCovariance, self).__init__(
             x, y, z, params, debiased, kappa
@@ -483,15 +483,15 @@ class KernelCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-        self,
-        x: Float64Array,
-        y: Float64Array,
-        z: Float64Array,
-        params: Float64Array,
-        kernel: str = "bartlett",
-        bandwidth: OptionalNumeric = None,
-        debiased: bool = False,
-        kappa: Numeric = 1,
+            self,
+            x: Float64Array,
+            y: Float64Array,
+            z: Float64Array,
+            params: Float64Array,
+            kernel: str = "bartlett",
+            bandwidth: OptionalNumeric = None,
+            debiased: bool = False,
+            kappa: Numeric = 1,
     ):
         super(KernelCovariance, self).__init__(x, y, z, params, debiased, kappa)
         self._kernels = KERNEL_LOOKUP
@@ -603,14 +603,14 @@ class ClusteredCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-        self,
-        x: Float64Array,
-        y: Float64Array,
-        z: Float64Array,
-        params: Float64Array,
-        clusters: Optional[AnyArray] = None,
-        debiased: bool = False,
-        kappa: Numeric = 1,
+            self,
+            x: Float64Array,
+            y: Float64Array,
+            z: Float64Array,
+            params: Float64Array,
+            clusters: Optional[AnyArray] = None,
+            debiased: bool = False,
+            kappa: Numeric = 1,
     ):
         super(ClusteredCovariance, self).__init__(x, y, z, params, debiased, kappa)
 
@@ -947,8 +947,8 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
             Zi = self.z[int(sum(ng[:i + 1]) - ng[i]): int(sum(ng[:i + 1])), :]
             e1i = eps[int(sum(ng[:i + 1]) - ng[i]): int(sum(ng[:i + 1]))]
             DXi = self.x[int(sum(ng[:i + 1]) - ng[i]): int(sum(ng[:i + 1])), :]
-            psi1 = Q.T @ inv(wmat) @ Zi.T @ e1i - DXi.T @ Zi @ inv(wmat) @ mu1 - \
-                   Q.T @ inv(wmat) @ W0i[:, :, i] @ inv(wmat) @ mu1
+            psi_temp = Q.T @ inv(wmat) @ W0i[:, :, i] @ inv(wmat) @ mu1
+            psi1 = Q.T @ inv(wmat) @ Zi.T @ e1i - DXi.T @ Zi @ inv(wmat) @ mu1 - psi_temp
             Om1 += psi1 @ psi1.T
         Om1 /= nobs
         H0 = Q.T @ inv(wmat) @ Q

--- a/linearmodels/iv/covariance.py
+++ b/linearmodels/iv/covariance.py
@@ -7,13 +7,27 @@ from __future__ import annotations
 from typing import Any, Callable, Dict, Optional, Union, cast
 
 from mypy_extensions import VarArg
-from numpy import (arange, asarray, ceil, cos, diagflat, empty, int64, kron,
-                   ndarray, ones, pi, sin, sum as npsum, unique, zeros)
+from numpy import (
+    arange,
+    asarray,
+    ceil,
+    cos,
+    empty,
+    int64,
+    ndarray,
+    ones,
+    pi,
+    sin,
+    sum as npsum,
+    unique,
+    zeros,
+    diagflat,
+    kron,
+)
 from numpy.linalg import inv, pinv
 
 from linearmodels.shared.covariance import cov_cluster, cov_kernel
-from linearmodels.typing import (AnyArray, Float64Array, Numeric,
-                                 OptionalNumeric)
+from linearmodels.typing import AnyArray, Float64Array, Numeric, OptionalNumeric
 
 KernelWeight = Union[
     Callable[[float, float], ndarray],
@@ -118,7 +132,7 @@ def kernel_weight_parzen(bw: float, *args: int) -> Float64Array:
        w_i &  = 2(1-z_i)^3, z > 0.5
     """
     z = arange(int(bw) + 1) / (int(bw) + 1)
-    w = 1 - 6 * z**2 + 6 * z**3
+    w = 1 - 6 * z ** 2 + 6 * z ** 3
     w[z > 0.5] = 2 * (1 - z[z > 0.5]) ** 3
     return w
 
@@ -175,7 +189,7 @@ def kernel_optimal_bandwidth(x: Float64Array, kernel: str = "bartlett") -> int:
     sq = 2 * npsum(sigma[1:] * arange(1, m_star + 1) ** q)
     rate = 1 / (2 * q + 1)
     gamma = c * ((sq / s0) ** 2) ** rate
-    m = gamma * t**rate
+    m = gamma * t ** rate
     return min(int(ceil(m)), t - 1)
 
 
@@ -210,6 +224,7 @@ class HomoskedasticCovariance(object):
         Value of kappa in k-class estimator
     w : ndarray
         the iter GMM weight matrix
+
     Notes
     -----
     Covariance is estimated using
@@ -235,14 +250,14 @@ class HomoskedasticCovariance(object):
     """
 
     def __init__(
-        self,
-        x: Float64Array,
-        y: Float64Array,
-        z: Float64Array,
-        params: Float64Array,
-        debiased: bool = False,
-        kappa: Numeric = 1,
-        w: Float64Array = zeros(1),
+            self,
+            x: Float64Array,
+            y: Float64Array,
+            z: Float64Array,
+            params: Float64Array,
+            debiased: bool = False,
+            kappa: Numeric = 1,
+            w: Float64Array = zeros(1),
     ):
         if not (x.shape[0] == y.shape[0] == z.shape[0]):
             raise ValueError("x, y and z must have the same number of rows")
@@ -271,10 +286,10 @@ class HomoskedasticCovariance(object):
 
     def __repr__(self) -> str:
         return (
-            self.__str__()
-            + "\n"
-            + self.__class__.__name__
-            + ", id: {0}".format(hex(id(self)))
+                self.__str__()
+                + "\n"
+                + self.__class__.__name__
+                + ", id: {0}".format(hex(id(self)))
         )
 
     @property
@@ -376,13 +391,13 @@ class HeteroskedasticCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-        self,
-        x: Float64Array,
-        y: Float64Array,
-        z: Float64Array,
-        params: Float64Array,
-        debiased: bool = False,
-        kappa: Numeric = 1,
+            self,
+            x: Float64Array,
+            y: Float64Array,
+            z: Float64Array,
+            params: Float64Array,
+            debiased: bool = False,
+            kappa: Numeric = 1,
     ):
         super(HeteroskedasticCovariance, self).__init__(
             x, y, z, params, debiased, kappa
@@ -469,15 +484,15 @@ class KernelCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-        self,
-        x: Float64Array,
-        y: Float64Array,
-        z: Float64Array,
-        params: Float64Array,
-        kernel: str = "bartlett",
-        bandwidth: OptionalNumeric = None,
-        debiased: bool = False,
-        kappa: Numeric = 1,
+            self,
+            x: Float64Array,
+            y: Float64Array,
+            z: Float64Array,
+            params: Float64Array,
+            kernel: str = "bartlett",
+            bandwidth: OptionalNumeric = None,
+            debiased: bool = False,
+            kappa: Numeric = 1,
     ):
         super(KernelCovariance, self).__init__(x, y, z, params, debiased, kappa)
         self._kernels = KERNEL_LOOKUP
@@ -589,14 +604,14 @@ class ClusteredCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-        self,
-        x: Float64Array,
-        y: Float64Array,
-        z: Float64Array,
-        params: Float64Array,
-        clusters: Optional[AnyArray] = None,
-        debiased: bool = False,
-        kappa: Numeric = 1,
+            self,
+            x: Float64Array,
+            y: Float64Array,
+            z: Float64Array,
+            params: Float64Array,
+            clusters: Optional[AnyArray] = None,
+            debiased: bool = False,
+            kappa: Numeric = 1,
     ):
         super(ClusteredCovariance, self).__init__(x, y, z, params, debiased, kappa)
 
@@ -721,15 +736,15 @@ class MisspecificationCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-        self,
-        x: Float64Array,
-        y: Float64Array,
-        z: Float64Array,
-        params: Float64Array,
-        clusters: Optional[AnyArray] = None,
-        debiased: bool = False,
-        kappa: Numeric = 1,
-        w: Float64Array = zeros(1),
+            self,
+            x: Float64Array,
+            y: Float64Array,
+            z: Float64Array,
+            params: Float64Array,
+            clusters: Optional[AnyArray] = None,
+            debiased: bool = False,
+            kappa: Numeric = 1,
+            w: Float64Array = zeros(1),
     ):
         super(MisspecificationCovariance, self).__init__(
             x, y, z, params, debiased, kappa, w
@@ -761,7 +776,7 @@ class MisspecificationCovariance(HomoskedasticCovariance):
 
     @property
     def s(self) -> Float64Array:
-        def repmat(self, a: Float64Array, b: int, c: int) -> Float64Array:
+        def repmat(a: Float64Array, b: int, c: int) -> Float64Array:
             """
             Parameters
             ----------
@@ -795,7 +810,7 @@ class MisspecificationCovariance(HomoskedasticCovariance):
         eTz = eps.T @ self.z
         zTx = self.z.T @ self.x
         xTz = self.x.T @ self.z
-        idx = repmat(self, mem, 1, G).T == kron(
+        idx = repmat(mem, 1, G).T == kron(
             ones((nobs, 1)), unique(mem).reshape(1, -1)
         )
         for g in range(G):
@@ -806,15 +821,15 @@ class MisspecificationCovariance(HomoskedasticCovariance):
             zgTxg = zg.T @ xg
 
             Hpart = (
-                Hpart + zgTeg @ eTz @ invw @ zgTxg + zgTxg * (eTz @ invw @ zgTeg)[0][0]
+                    Hpart + zgTeg @ eTz @ invw @ zgTxg + zgTxg * (eTz @ invw @ zgTeg)[0][0]
             )
             Psi[g, :] = (
-                -(1 / nobs) * xTz @ invw @ zgTeg
-                - (1 / nobs) * (xg.T @ zg) @ invw @ zTe
-                + (1 / nobs**2) * xTz @ invw @ zgTeg @ (eg.T @ zg) @ invw @ zTe
+                    -(1 / nobs) * xTz @ invw @ zgTeg
+                    - (1 / nobs) * (xg.T @ zg) @ invw @ zTe
+                    + (1 / nobs ** 2) * xTz @ invw @ zgTeg @ (eg.T @ zg) @ invw @ zTe
             ).T
 
-        H = (1 / nobs**2) * xTz @ invw @ zTx - (1 / nobs**3) * xTz @ invw @ Hpart
+        H = (1 / nobs ** 2) * xTz @ invw @ zTx - (1 / nobs ** 3) * xTz @ invw @ Hpart
 
         Om = (Psi.T @ Psi) / nobs
 
@@ -854,14 +869,14 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
     """
 
     def __init__(
-        self,
-        x: Float64Array,
-        y: Float64Array,
-        z: Float64Array,
-        params: Float64Array,
-        clusters: Optional[AnyArray] = None,
-        debiased: bool = False,
-        kappa: Numeric = 1,
+            self,
+            x: Float64Array,
+            y: Float64Array,
+            z: Float64Array,
+            params: Float64Array,
+            clusters: Optional[AnyArray] = None,
+            debiased: bool = False,
+            kappa: Numeric = 1,
     ):
         super(OneStepMisspecificationCovariance, self).__init__(
             x, y, z, params, debiased, kappa
@@ -923,7 +938,7 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
         wmat = zeros((z_num, z_num))
         W0i = zeros((z_num, z_num, G))
         for i in range(G):
-            Zi = self.z[int(sum(ng[0 : i + 1]) - ng[i]) : int(sum(ng[0 : i + 1])), :]
+            Zi = self.z[int(sum(ng[0: i + 1]) - ng[i]): int(sum(ng[0: i + 1])), :]
 
             h0 = 2 * ones((int(ng[i]), 1))
             h1 = -1 * ones((int(ng[i]) - 1, 1))
@@ -936,12 +951,12 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
         mu1 = (self.z.T @ eps) / nobs
         Q = -(self.z.T @ self.x) / nobs
         for i in range(G):
-            Zi = self.z[int(sum(ng[: i + 1]) - ng[i]) : int(sum(ng[: i + 1])), :]
-            e1i = eps[int(sum(ng[: i + 1]) - ng[i]) : int(sum(ng[: i + 1]))]
-            DXi = self.x[int(sum(ng[: i + 1]) - ng[i]) : int(sum(ng[: i + 1])), :]
+            Zi = self.z[int(sum(ng[: i + 1]) - ng[i]): int(sum(ng[: i + 1])), :]
+            e1i = eps[int(sum(ng[: i + 1]) - ng[i]): int(sum(ng[: i + 1]))]
+            DXi = self.x[int(sum(ng[: i + 1]) - ng[i]): int(sum(ng[: i + 1])), :]
             psi_temp = Q.T @ inv(wmat) @ W0i[:, :, i] @ inv(wmat) @ mu1
             psi1 = (
-                Q.T @ inv(wmat) @ Zi.T @ e1i - DXi.T @ Zi @ inv(wmat) @ mu1 - psi_temp
+                    Q.T @ inv(wmat) @ Zi.T @ e1i - DXi.T @ Zi @ inv(wmat) @ mu1 - psi_temp
             )
             Om1 += psi1 @ psi1.T
         Om1 /= nobs

--- a/linearmodels/iv/covariance.py
+++ b/linearmodels/iv/covariance.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, Optional, Union, cast
 
 from mypy_extensions import VarArg
 from numpy import (
+    sum as npsum,
     arange,
     asarray,
     ceil,
@@ -18,7 +19,6 @@ from numpy import (
     ones,
     pi,
     sin,
-    sum as npsum,
     unique,
     zeros,
     diagflat,
@@ -284,9 +284,8 @@ class HomoskedasticCovariance(object):
         return out
 
     def __repr__(self) -> str:
-        return (
-                self.__str__() + "\n" + self.__class__.__name__ + ", id: {0}".format(hex(id(self)))
-        )
+        return (self.__str__() + "\n" + self.__class__.__name__ + ", id: {0}".
+                format(hex(id(self))))
 
     @property
     def s(self) -> Float64Array:

--- a/linearmodels/iv/covariance.py
+++ b/linearmodels/iv/covariance.py
@@ -285,10 +285,7 @@ class HomoskedasticCovariance(object):
 
     def __repr__(self) -> str:
         return (
-                self.__str__()
-                + "\n"
-                + self.__class__.__name__
-                + ", id: {0}".format(hex(id(self)))
+                self.__str__() + "\n" + self.__class__.__name__ + ", id: {0}".format(hex(id(self)))
         )
 
     @property

--- a/linearmodels/iv/covariance.py
+++ b/linearmodels/iv/covariance.py
@@ -1,4 +1,4 @@
-"""Covariance estimation for 2SLS and LIML IV estimators"""
+"""Covariance estimation for 2SLS and LIML IV estimators."""
 
 from __future__ import annotations
 
@@ -135,7 +135,7 @@ def kernel_weight_parzen(bw: float, *args: int) -> Float64Array:
 
 
 def kernel_optimal_bandwidth(x: Float64Array, kernel: str = "bartlett") -> int:
-    """
+    r"""
     Parameters
     x : ndarray
         Array of data to use when computing optimal bandwidth
@@ -164,6 +164,7 @@ def kernel_optimal_bandwidth(x: Float64Array, kernel: str = "bartlett") -> int:
     linearmodels.iv.covariance.kernel_weight_bartlett,
     linearmodels.iv.covariance.kernel_weight_parzen,
     linearmodels.iv.covariance.kernel_weight_quadratic_spectral
+
     """
     t = x.shape[0]
     x = x.squeeze()
@@ -289,7 +290,7 @@ class HomoskedasticCovariance(object):
 
     @property
     def s(self) -> Float64Array:
-        """Score covariance estimate"""
+        """Score covariance estimate."""
         x, z, eps = self.x, self.z, self.eps
         nobs = x.shape[0]
         s2 = eps.T @ eps / nobs
@@ -304,7 +305,7 @@ class HomoskedasticCovariance(object):
 
     @property
     def cov(self) -> Float64Array:
-        """Covariance of estimated parameters"""
+        """Covariance of estimated parameters."""
 
         x, z = self.x, self.z
         nobs = x.shape[0]
@@ -332,7 +333,7 @@ class HomoskedasticCovariance(object):
 
     @property
     def debiased(self) -> bool:
-        """Flag indicating if covariance is debiased"""
+        """Flag indicating if covariance is debiased."""
         return self._debiased
 
     @property
@@ -401,9 +402,9 @@ class HeteroskedasticCovariance(HomoskedasticCovariance):
 
     @property
     def s(self) -> Float64Array:
-        """Heteroskedasticity-robust score covariance estimate"""
+        """Heteroskedasticity-robust score covariance estimate."""
         x, z, eps = self.x, self.z, self.eps
-        nobs, nvar = x.shape
+        nobs = x.shape[1]
         pinvz = self._pinvz
         xhat_e = z @ (pinvz @ x) * eps
         s = xhat_e.T @ xhat_e / nobs
@@ -509,7 +510,7 @@ class KernelCovariance(HomoskedasticCovariance):
 
     @property
     def s(self) -> Float64Array:
-        """HAC score covariance estimate"""
+        """HAC score covariance estimate."""
         x, z, eps = self.x, self.z, self.eps
         nobs, nvar = x.shape
 

--- a/linearmodels/iv/covariance.py
+++ b/linearmodels/iv/covariance.py
@@ -1,6 +1,4 @@
-"""
-Covariance estimation for 2SLS and LIML IV estimators
-"""
+"""Covariance estimation for 2SLS and LIML IV estimators"""
 
 from __future__ import annotations
 
@@ -309,7 +307,7 @@ class HomoskedasticCovariance(object):
         """Covariance of estimated parameters"""
 
         x, z = self.x, self.z
-        nobs, nvar = x.shape
+        nobs = x.shape[0]
 
         pinvz = self._pinvz
         v = (x.T @ z) @ (pinvz @ x) / nobs
@@ -639,7 +637,7 @@ class ClusteredCovariance(HomoskedasticCovariance):
 
     @property
     def s(self) -> Float64Array:
-        """Clustered estimator of score covariance"""
+        """Clustered estimator of score covariance."""
 
         def rescale(s: Float64Array, nc: int, nobs: int) -> Float64Array:
             scale = float(self._scale * (nc / (nc - 1)) * ((nobs - 1) / nobs))
@@ -926,18 +924,16 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
     def s(self) -> Float64Array:
 
         def conutnum(x: Float64Array, binranges: Float64Array) -> Float64Array:
-            '''
-            Bin counting for histograms, equal to MATLAB fun:histc
-            '''
+            """Bin counting for histograms, equal to MATLAB fun:histc."""
             temp = zeros((len(binranges), 2))
             temp[:, 0] = binranges
-            for i in range(len(binranges)):
+            for i, element in enumerate(binranges):
                 if i == 0:
                     temp[i, 1] = npsum((x <= binranges[0]))
                 elif i == len(binranges) - 1:
-                    temp[i, 1] = npsum((x >= binranges[i]))
+                    temp[i, 1] = npsum((x >= element))
                 else:
-                    temp[i, 1] = npsum((x > binranges[i - 1]) & (x <= binranges[i]))
+                    temp[i, 1] = npsum((x > binranges[i - 1]) & (x <= element))
             return temp
 
         nobs, nvar = self.x.shape
@@ -949,7 +945,7 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
                 "got {1}".format(nobs, clusters.shape[0])
             )
 
-        cc, mem = unique(clusters, return_inverse=True)
+        cc = unique(clusters)
         G = int(len(cc))
         g_ng = conutnum(clusters[:], cc)
         ng = g_ng[:, 1]
@@ -963,7 +959,7 @@ class OneStepMisspecificationCovariance(HomoskedasticCovariance):
             h1 = -1 * ones((int(ng[i]) - 1, 1))
             Hm = diagflat(h0) + diagflat(h1, 1) + diagflat(h1, -1)
 
-            W0i[:, :, i] = Zi.T @ Hm @ Zi;
+            W0i[:, :, i] = Zi.T @ Hm @ Zi
             wmat = wmat + W0i[:, :, i]
         wmat = wmat / nobs
         Om1 = zeros((nvar, nvar))

--- a/linearmodels/iv/gmm.py
+++ b/linearmodels/iv/gmm.py
@@ -1,4 +1,4 @@
-"""Covariance and weight estimation for GMM IV estimators"""
+"""Covariance and weight estimation for GMM IV estimators."""
 
 from __future__ import annotations
 
@@ -18,8 +18,8 @@ from numpy.linalg import inv
 
 
 class HomoskedasticWeightMatrix(object):
-
     r"""
+
     Homoskedastic (unadjusted) weight estimation
 
     Parameters
@@ -52,7 +52,7 @@ class HomoskedasticWeightMatrix(object):
     def weight_matrix(
             self, x: Float64Array, z: Float64Array, eps: Float64Array
     ) -> Float64Array:
-        """
+        r"""
         Parameters
         ----------
         x : ndarray

--- a/linearmodels/iv/gmm.py
+++ b/linearmodels/iv/gmm.py
@@ -6,14 +6,23 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional, Union
 
-from numpy import (asarray, diagflat, dot, kron, ndarray, ones, sum as npsum,
-                   unique, zeros)
+from numpy import (
+    asarray,
+    diagflat,
+    dot,
+    kron,
+    ndarray,
+    ones,
+    sum as npsum,
+    unique,
+    zeros)
 from numpy.linalg import inv
 
-from linearmodels.iv.covariance import (KERNEL_LOOKUP, HomoskedasticCovariance,
-                                        MisspecificationCovariance,
-                                        OneStepMisspecificationCovariance,
-                                        kernel_optimal_bandwidth)
+from linearmodels.iv.covariance import (
+    KERNEL_LOOKUP,
+    HomoskedasticCovariance,
+    kernel_optimal_bandwidth,
+)
 from linearmodels.shared.covariance import cov_cluster, cov_kernel
 from linearmodels.typing import AnyArray, Float64Array
 
@@ -50,7 +59,7 @@ class HomoskedasticWeightMatrix(object):
         self._bandwidth: Optional[int] = 0
 
     def weight_matrix(
-        self, x: Float64Array, z: Float64Array, eps: Float64Array
+            self, x: Float64Array, z: Float64Array, eps: Float64Array
     ) -> Float64Array:
         """
         Parameters
@@ -115,7 +124,7 @@ class HeteroskedasticWeightMatrix(HomoskedasticWeightMatrix):
         super(HeteroskedasticWeightMatrix, self).__init__(center, debiased)
 
     def weight_matrix(
-        self, x: Float64Array, z: Float64Array, eps: Float64Array
+            self, x: Float64Array, z: Float64Array, eps: Float64Array
     ) -> Float64Array:
         """
         Parameters
@@ -186,12 +195,12 @@ class KernelWeightMatrix(HomoskedasticWeightMatrix):
     """
 
     def __init__(
-        self,
-        kernel: str = "bartlett",
-        bandwidth: Optional[int] = None,
-        center: bool = False,
-        debiased: bool = False,
-        optimal_bw: bool = False,
+            self,
+            kernel: str = "bartlett",
+            bandwidth: Optional[int] = None,
+            center: bool = False,
+            debiased: bool = False,
+            optimal_bw: bool = False,
     ) -> None:
         super(KernelWeightMatrix, self).__init__(center, debiased)
         self._bandwidth = bandwidth
@@ -201,7 +210,7 @@ class KernelWeightMatrix(HomoskedasticWeightMatrix):
         self._optimal_bw = optimal_bw
 
     def weight_matrix(
-        self, x: Float64Array, z: Float64Array, eps: Float64Array
+            self, x: Float64Array, z: Float64Array, eps: Float64Array
     ) -> Float64Array:
         """
         Parameters
@@ -277,13 +286,13 @@ class OneWayClusteredWeightMatrix(HomoskedasticWeightMatrix):
     """
 
     def __init__(
-        self, clusters: AnyArray, center: bool = False, debiased: bool = False
+            self, clusters: AnyArray, center: bool = False, debiased: bool = False
     ) -> None:
         super(OneWayClusteredWeightMatrix, self).__init__(center, debiased)
         self._clusters = clusters
 
     def weight_matrix(
-        self, x: Float64Array, z: Float64Array, eps: Float64Array
+            self, x: Float64Array, z: Float64Array, eps: Float64Array
     ) -> Float64Array:
         """
         Parameters
@@ -343,6 +352,10 @@ class OneWayClusteredWeightMatrix(HomoskedasticWeightMatrix):
 def conutnum(x: Float64Array, binranges: Float64Array) -> Float64Array:
     """
     Bin counting for histograms, equal to MATLAB fun:histc
+    Returns
+    -------
+    ndarray
+        Ndarray of bin counting for histograms
     """
     temp = zeros((len(binranges), 2))
     temp[:, 0] = binranges
@@ -371,13 +384,13 @@ class OneStepMisspecificationWeightMatrix(HomoskedasticWeightMatrix):
     """
 
     def __init__(
-        self, clusters: AnyArray, center: bool = False, debiased: bool = False
+            self, clusters: AnyArray, center: bool = False, debiased: bool = False
     ) -> None:
         super(OneStepMisspecificationWeightMatrix, self).__init__(center, debiased)
         self._clusters = clusters
 
     def weight_matrix(
-        self, x: Float64Array, z: Float64Array, eps: Float64Array
+            self, x: Float64Array, z: Float64Array, eps: Float64Array
     ) -> Float64Array:
         """
         Parameters
@@ -410,7 +423,7 @@ class OneStepMisspecificationWeightMatrix(HomoskedasticWeightMatrix):
         wmat = zeros((z_num, z_num))
         W0i = zeros((z_num, z_num, G))
         for i in range(G):
-            Zi = z[int(npsum(ng[0 : i + 1]) - ng[i]) : int(npsum(ng[0 : i + 1])), :]
+            Zi = z[int(npsum(ng[0: i + 1]) - ng[i]): int(npsum(ng[0: i + 1])), :]
 
             h0 = 2 * ones((int(ng[i]), 1))
             h1 = -1 * ones((int(ng[i]) - 1, 1))
@@ -469,13 +482,13 @@ class MisspecificationWeightMatrix(HomoskedasticWeightMatrix):
     """
 
     def __init__(
-        self, clusters: AnyArray, center: bool = False, debiased: bool = False
+            self, clusters: AnyArray, center: bool = False, debiased: bool = False
     ) -> None:
         super(MisspecificationWeightMatrix, self).__init__(center, debiased)
         self._clusters = clusters
 
     def weight_matrix(
-        self, x: Float64Array, z: Float64Array, eps: Float64Array
+            self, x: Float64Array, z: Float64Array, eps: Float64Array
     ) -> Float64Array:
         """
         Parameters
@@ -596,15 +609,15 @@ class IVGMMCovariance(HomoskedasticCovariance):
 
     # TODO: 2-way clustering
     def __init__(
-        self,
-        x: Float64Array,
-        y: Float64Array,
-        z: Float64Array,
-        params: Float64Array,
-        w: Float64Array,
-        cov_type: str = "robust",
-        debiased: bool = False,
-        **cov_config: Union[str, bool],
+            self,
+            x: Float64Array,
+            y: Float64Array,
+            z: Float64Array,
+            params: Float64Array,
+            w: Float64Array,
+            cov_type: str = "robust",
+            debiased: bool = False,
+            **cov_config: Union[str, bool],
     ) -> None:
         super(IVGMMCovariance, self).__init__(x, y, z, params, debiased)
         self._cov_type = cov_type
@@ -689,6 +702,7 @@ class IVGMMCovariance(HomoskedasticCovariance):
                 w=self.w,
             ).s
         else:
+
             nobs = x.shape[0]
             xpz = x.T @ z / nobs
             xpzw = xpz @ w
@@ -696,6 +710,7 @@ class IVGMMCovariance(HomoskedasticCovariance):
             s = score_cov.weight_matrix(x, z, eps)
             c = xpzwzpx_inv @ (xpzw @ s @ xpzw.T) @ xpzwzpx_inv / nobs
             c = (c + c.T) / 2
+
         return c
 
     @property

--- a/linearmodels/iv/gmm.py
+++ b/linearmodels/iv/gmm.py
@@ -6,16 +6,14 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional, Union
 
-from numpy import sum as npsum, asarray, ndarray, unique, zeros, ones, diagflat, kron, dot
+from numpy import (asarray, diagflat, dot, kron, ndarray, ones, sum as npsum,
+                   unique, zeros)
 from numpy.linalg import inv
 
-from linearmodels.iv.covariance import (
-    KERNEL_LOOKUP,
-    HomoskedasticCovariance,
-    kernel_optimal_bandwidth,
-    MisspecificationCovariance,
-    OneStepMisspecificationCovariance,
-)
+from linearmodels.iv.covariance import (KERNEL_LOOKUP, HomoskedasticCovariance,
+                                        MisspecificationCovariance,
+                                        OneStepMisspecificationCovariance,
+                                        kernel_optimal_bandwidth)
 from linearmodels.shared.covariance import cov_cluster, cov_kernel
 from linearmodels.typing import AnyArray, Float64Array
 
@@ -52,7 +50,7 @@ class HomoskedasticWeightMatrix(object):
         self._bandwidth: Optional[int] = 0
 
     def weight_matrix(
-            self, x: Float64Array, z: Float64Array, eps: Float64Array
+        self, x: Float64Array, z: Float64Array, eps: Float64Array
     ) -> Float64Array:
         """
         Parameters
@@ -117,7 +115,7 @@ class HeteroskedasticWeightMatrix(HomoskedasticWeightMatrix):
         super(HeteroskedasticWeightMatrix, self).__init__(center, debiased)
 
     def weight_matrix(
-            self, x: Float64Array, z: Float64Array, eps: Float64Array
+        self, x: Float64Array, z: Float64Array, eps: Float64Array
     ) -> Float64Array:
         """
         Parameters
@@ -188,12 +186,12 @@ class KernelWeightMatrix(HomoskedasticWeightMatrix):
     """
 
     def __init__(
-            self,
-            kernel: str = "bartlett",
-            bandwidth: Optional[int] = None,
-            center: bool = False,
-            debiased: bool = False,
-            optimal_bw: bool = False,
+        self,
+        kernel: str = "bartlett",
+        bandwidth: Optional[int] = None,
+        center: bool = False,
+        debiased: bool = False,
+        optimal_bw: bool = False,
     ) -> None:
         super(KernelWeightMatrix, self).__init__(center, debiased)
         self._bandwidth = bandwidth
@@ -203,7 +201,7 @@ class KernelWeightMatrix(HomoskedasticWeightMatrix):
         self._optimal_bw = optimal_bw
 
     def weight_matrix(
-            self, x: Float64Array, z: Float64Array, eps: Float64Array
+        self, x: Float64Array, z: Float64Array, eps: Float64Array
     ) -> Float64Array:
         """
         Parameters
@@ -279,13 +277,13 @@ class OneWayClusteredWeightMatrix(HomoskedasticWeightMatrix):
     """
 
     def __init__(
-            self, clusters: AnyArray, center: bool = False, debiased: bool = False
+        self, clusters: AnyArray, center: bool = False, debiased: bool = False
     ) -> None:
         super(OneWayClusteredWeightMatrix, self).__init__(center, debiased)
         self._clusters = clusters
 
     def weight_matrix(
-            self, x: Float64Array, z: Float64Array, eps: Float64Array
+        self, x: Float64Array, z: Float64Array, eps: Float64Array
     ) -> Float64Array:
         """
         Parameters
@@ -373,13 +371,13 @@ class OneStepMisspecificationWeightMatrix(HomoskedasticWeightMatrix):
     """
 
     def __init__(
-            self, clusters: AnyArray, center: bool = False, debiased: bool = False
+        self, clusters: AnyArray, center: bool = False, debiased: bool = False
     ) -> None:
         super(OneStepMisspecificationWeightMatrix, self).__init__(center, debiased)
         self._clusters = clusters
 
     def weight_matrix(
-            self, x: Float64Array, z: Float64Array, eps: Float64Array
+        self, x: Float64Array, z: Float64Array, eps: Float64Array
     ) -> Float64Array:
         """
         Parameters
@@ -412,7 +410,7 @@ class OneStepMisspecificationWeightMatrix(HomoskedasticWeightMatrix):
         wmat = zeros((z_num, z_num))
         W0i = zeros((z_num, z_num, G))
         for i in range(G):
-            Zi = z[int(npsum(ng[0:i + 1]) - ng[i]): int(npsum(ng[0:i + 1])), :]
+            Zi = z[int(npsum(ng[0 : i + 1]) - ng[i]) : int(npsum(ng[0 : i + 1])), :]
 
             h0 = 2 * ones((int(ng[i]), 1))
             h1 = -1 * ones((int(ng[i]) - 1, 1))
@@ -440,9 +438,7 @@ class OneStepMisspecificationWeightMatrix(HomoskedasticWeightMatrix):
         }
 
 
-def repmat(
-        a: Float64Array, b: int, c: int
-) -> Float64Array:
+def repmat(a: Float64Array, b: int, c: int) -> Float64Array:
     """
     Parameters
     ----------
@@ -473,13 +469,13 @@ class MisspecificationWeightMatrix(HomoskedasticWeightMatrix):
     """
 
     def __init__(
-            self, clusters: AnyArray, center: bool = False, debiased: bool = False
+        self, clusters: AnyArray, center: bool = False, debiased: bool = False
     ) -> None:
         super(MisspecificationWeightMatrix, self).__init__(center, debiased)
         self._clusters = clusters
 
     def weight_matrix(
-            self, x: Float64Array, z: Float64Array, eps: Float64Array
+        self, x: Float64Array, z: Float64Array, eps: Float64Array
     ) -> Float64Array:
         """
         Parameters
@@ -510,11 +506,12 @@ class MisspecificationWeightMatrix(HomoskedasticWeightMatrix):
         wmat = zeros((z_num, z_num))
         cc = unique(clusters)
         G = int(len(cc))
-        idx = self.repmat(clusters, 1, G).T == kron(ones((nobs, 1)),
-                                                    unique(clusters).reshape(1, -1))
+        idx = self.repmat(clusters, 1, G).T == kron(
+            ones((nobs, 1)), unique(clusters).reshape(1, -1)
+        )
         if nobs == G:
             ze = dot(z, repmat(eps, 1, z_num).T)
-            wmat = (ze.T @ ze)
+            wmat = ze.T @ ze
         else:
             for g in range(G):
                 zg = z[idx[:, g], :]
@@ -599,15 +596,15 @@ class IVGMMCovariance(HomoskedasticCovariance):
 
     # TODO: 2-way clustering
     def __init__(
-            self,
-            x: Float64Array,
-            y: Float64Array,
-            z: Float64Array,
-            params: Float64Array,
-            w: Float64Array,
-            cov_type: str = "robust",
-            debiased: bool = False,
-            **cov_config: Union[str, bool],
+        self,
+        x: Float64Array,
+        y: Float64Array,
+        z: Float64Array,
+        params: Float64Array,
+        w: Float64Array,
+        cov_type: str = "robust",
+        debiased: bool = False,
+        **cov_config: Union[str, bool],
     ) -> None:
         super(IVGMMCovariance, self).__init__(x, y, z, params, debiased)
         self._cov_type = cov_type
@@ -672,14 +669,25 @@ class IVGMMCovariance(HomoskedasticCovariance):
             debiased=self.debiased, **self._cov_config
         )
         self._cov_config = score_cov.config
-        if self._cov_type == 'OneStepMisspecification':
-            c = OneStepMisspecificationCovariance(self.x, self.y, self.z, self.params,
-                                                  self.config['clusters'],
-                                                  self.config['debiased']).s
-        elif self._cov_type == 'Misspecification':
-            c = MisspecificationCovariance(self.x, self.y, self.z, self.params,
-                                           self.config['clusters'], self.config['debiased'],
-                                           w=self.w).s
+        if self._cov_type == "OneStepMisspecification":
+            c = OneStepMisspecificationCovariance(
+                self.x,
+                self.y,
+                self.z,
+                self.params,
+                self.config["clusters"],
+                self.config["debiased"],
+            ).s
+        elif self._cov_type == "Misspecification":
+            c = MisspecificationCovariance(
+                self.x,
+                self.y,
+                self.z,
+                self.params,
+                self.config["clusters"],
+                self.config["debiased"],
+                w=self.w,
+            ).s
         else:
             nobs = x.shape[0]
             xpz = x.T @ z / nobs

--- a/linearmodels/iv/gmm.py
+++ b/linearmodels/iv/gmm.py
@@ -22,6 +22,8 @@ from linearmodels.iv.covariance import (
     KERNEL_LOOKUP,
     HomoskedasticCovariance,
     kernel_optimal_bandwidth,
+    MisspecificationCovariance,
+    OneStepMisspecificationCovariance,
 )
 from linearmodels.shared.covariance import cov_cluster, cov_kernel
 from linearmodels.typing import AnyArray, Float64Array

--- a/linearmodels/iv/gmm.py
+++ b/linearmodels/iv/gmm.py
@@ -1,6 +1,4 @@
-"""
-Covariance and weight estimation for GMM IV estimators
-"""
+"""Covariance and weight estimation for GMM IV estimators"""
 
 from __future__ import annotations
 
@@ -20,6 +18,7 @@ from numpy.linalg import inv
 
 
 class HomoskedasticWeightMatrix(object):
+
     r"""
     Homoskedastic (unadjusted) weight estimation
 
@@ -428,7 +427,7 @@ class MisspecificationWeightMatrix(HomoskedasticWeightMatrix):
         clusters = asarray(clusters).copy().squeeze()
 
         wmat = zeros((z_num, z_num))
-        cc, mem = unique(clusters, return_inverse=True)
+        cc = unique(clusters)
         G = int(len(cc))
         idx = self.repmat(clusters, 1, G).T == kron(ones((nobs, 1)), unique(clusters).reshape(1, -1))
         if nobs == G:

--- a/linearmodels/iv/gmm.py
+++ b/linearmodels/iv/gmm.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional, Union
 
-from numpy import asarray, ndarray, unique, zeros, sum as npsum, ones, diagflat, kron, dot
+from numpy import sum as npsum, asarray, ndarray, unique, zeros, ones, diagflat, kron, dot
 from numpy.linalg import inv
 
 from linearmodels.iv.covariance import (

--- a/linearmodels/iv/model.py
+++ b/linearmodels/iv/model.py
@@ -6,36 +6,59 @@ from __future__ import annotations
 from typing import Any, Dict, Optional, Tuple, Type, TypeVar, Union, cast
 import warnings
 
-from numpy import (all as npall, any as npany, array, asarray, atleast_2d,
-                   average, c_, column_stack, eye, isscalar, logical_not,
-                   nanmean, ones, sqrt, zeros)
+from numpy import (
+    all as npall,
+    any as npany,
+    array,
+    asarray,
+    atleast_2d,
+    average,
+    c_,
+    column_stack,
+    eye,
+    isscalar,
+    logical_not,
+    nanmean,
+    ones,
+    sqrt,
+    zeros,
+)
 from numpy.linalg import eigvalsh, inv, matrix_rank, pinv
 from pandas import DataFrame, Series, concat
 from scipy.optimize import minimize
 
 from linearmodels.iv._utility import IVFormulaParser
 from linearmodels.iv.common import f_statistic, find_constant
-from linearmodels.iv.covariance import (ClusteredCovariance,
-                                        HeteroskedasticCovariance,
-                                        HomoskedasticCovariance,
-                                        KernelCovariance,
-                                        MisspecificationCovariance,
-                                        OneStepMisspecificationCovariance)
+from linearmodels.iv.covariance import (
+    ClusteredCovariance,
+    HeteroskedasticCovariance,
+    HomoskedasticCovariance,
+    KernelCovariance,
+    MisspecificationCovariance,
+    OneStepMisspecificationCovariance
+)
 from linearmodels.iv.data import IVData, IVDataLike
-from linearmodels.iv.gmm import (HeteroskedasticWeightMatrix,
-                                 HomoskedasticWeightMatrix, IVGMMCovariance,
-                                 KernelWeightMatrix,
-                                 MisspecificationWeightMatrix,
-                                 OneStepMisspecificationWeightMatrix,
-                                 OneWayClusteredWeightMatrix)
+from linearmodels.iv.gmm import (
+    HeteroskedasticWeightMatrix,
+    HomoskedasticWeightMatrix,
+    IVGMMCovariance,
+    KernelWeightMatrix,
+    OneWayClusteredWeightMatrix,
+    MisspecificationWeightMatrix,
+    OneStepMisspecificationWeightMatrix,
+)
 from linearmodels.iv.results import IVGMMResults, IVResults, OLSResults
 from linearmodels.shared.exceptions import IndexWarning, missing_warning
-from linearmodels.shared.hypotheses import (InvalidTestStatistic,
-                                            WaldTestStatistic)
+from linearmodels.shared.hypotheses import InvalidTestStatistic, WaldTestStatistic
 from linearmodels.shared.linalg import has_constant, inv_sqrth
 from linearmodels.shared.utility import DataFrameWrapper, SeriesWrapper
-from linearmodels.typing import (ArrayLike, BoolArray, Float64Array, Numeric,
-                                 OptionalNumeric)
+from linearmodels.typing import (
+    ArrayLike,
+    BoolArray,
+    Float64Array,
+    Numeric,
+    OptionalNumeric,
+)
 
 IVResultType = Type[Union[IVResults, IVGMMResults, OLSResults]]
 
@@ -1228,7 +1251,6 @@ class IVGMM(_IVGMMBase):
             initial_weight = asarray(initial_weight)
             if initial_weight.ndim != 2 or initial_weight.shape != (k_wz, k_wz):
                 raise ValueError(f"initial_weight must be a {k_wz} by {k_wz} array")
-
         if (self._weight_type == "OneStepMisspecification") and (iter_limit != 1):
             raise ValueError(
                 " weight_type: OneStepMisspecification must set iter_limit=1"

--- a/linearmodels/iv/model.py
+++ b/linearmodels/iv/model.py
@@ -1253,9 +1253,9 @@ class IVGMM(_IVGMMBase):
                 raise ValueError(f"initial_weight must be a {k_wz} by {k_wz} array")
 
         if (self._weight_type == 'OneStepMisspecification') and (iter_limit != 1):
-            raise ValueError(f" weight_type: OneStepMisspecification must set iter_limit=1")
+            raise ValueError(" weight_type: OneStepMisspecification must set iter_limit=1")
         elif (cov_type == 'OneStepMisspecification') and (iter_limit != 1):
-            raise ValueError(f" cov_type: OneStepMisspecification must set iter_limit=1")
+            raise ValueError(" cov_type: OneStepMisspecification must set iter_limit=1")
         if (iter_limit != 1) and (initial_weight is None) and \
                 (self._weight_type == 'OneStepMisspecification'):
             wmat = inv(weight_matrix(wx, wz, zeros((nobs, 1))))

--- a/linearmodels/iv/model.py
+++ b/linearmodels/iv/model.py
@@ -21,6 +21,7 @@ from numpy import (
     nanmean,
     ones,
     sqrt,
+    zeros,
 )
 from numpy.linalg import eigvalsh, inv, matrix_rank, pinv
 from pandas import DataFrame, Series, concat

--- a/linearmodels/iv/model.py
+++ b/linearmodels/iv/model.py
@@ -6,59 +6,36 @@ from __future__ import annotations
 from typing import Any, Dict, Optional, Tuple, Type, TypeVar, Union, cast
 import warnings
 
-from numpy import (
-    all as npall,
-    any as npany,
-    array,
-    asarray,
-    atleast_2d,
-    average,
-    c_,
-    column_stack,
-    eye,
-    isscalar,
-    logical_not,
-    nanmean,
-    ones,
-    sqrt,
-    zeros,
-)
+from numpy import (all as npall, any as npany, array, asarray, atleast_2d,
+                   average, c_, column_stack, eye, isscalar, logical_not,
+                   nanmean, ones, sqrt, zeros)
 from numpy.linalg import eigvalsh, inv, matrix_rank, pinv
 from pandas import DataFrame, Series, concat
 from scipy.optimize import minimize
 
 from linearmodels.iv._utility import IVFormulaParser
 from linearmodels.iv.common import f_statistic, find_constant
-from linearmodels.iv.covariance import (
-    ClusteredCovariance,
-    HeteroskedasticCovariance,
-    HomoskedasticCovariance,
-    KernelCovariance,
-    MisspecificationCovariance,
-    OneStepMisspecificationCovariance,
-)
+from linearmodels.iv.covariance import (ClusteredCovariance,
+                                        HeteroskedasticCovariance,
+                                        HomoskedasticCovariance,
+                                        KernelCovariance,
+                                        MisspecificationCovariance,
+                                        OneStepMisspecificationCovariance)
 from linearmodels.iv.data import IVData, IVDataLike
-from linearmodels.iv.gmm import (
-    HeteroskedasticWeightMatrix,
-    HomoskedasticWeightMatrix,
-    IVGMMCovariance,
-    KernelWeightMatrix,
-    OneWayClusteredWeightMatrix,
-    MisspecificationWeightMatrix,
-    OneStepMisspecificationWeightMatrix,
-)
+from linearmodels.iv.gmm import (HeteroskedasticWeightMatrix,
+                                 HomoskedasticWeightMatrix, IVGMMCovariance,
+                                 KernelWeightMatrix,
+                                 MisspecificationWeightMatrix,
+                                 OneStepMisspecificationWeightMatrix,
+                                 OneWayClusteredWeightMatrix)
 from linearmodels.iv.results import IVGMMResults, IVResults, OLSResults
 from linearmodels.shared.exceptions import IndexWarning, missing_warning
-from linearmodels.shared.hypotheses import InvalidTestStatistic, WaldTestStatistic
+from linearmodels.shared.hypotheses import (InvalidTestStatistic,
+                                            WaldTestStatistic)
 from linearmodels.shared.linalg import has_constant, inv_sqrth
 from linearmodels.shared.utility import DataFrameWrapper, SeriesWrapper
-from linearmodels.typing import (
-    ArrayLike,
-    BoolArray,
-    Float64Array,
-    Numeric,
-    OptionalNumeric,
-)
+from linearmodels.typing import (ArrayLike, BoolArray, Float64Array, Numeric,
+                                 OptionalNumeric)
 
 IVResultType = Type[Union[IVResults, IVGMMResults, OLSResults]]
 
@@ -97,7 +74,7 @@ CovarianceEstimator = TypeVar(
     KernelCovariance,
     ClusteredCovariance,
     MisspecificationCovariance,
-    OneStepMisspecificationCovariance
+    OneStepMisspecificationCovariance,
 )
 
 WEIGHT_MATRICES = {
@@ -1252,14 +1229,19 @@ class IVGMM(_IVGMMBase):
             if initial_weight.ndim != 2 or initial_weight.shape != (k_wz, k_wz):
                 raise ValueError(f"initial_weight must be a {k_wz} by {k_wz} array")
 
-        if (self._weight_type == 'OneStepMisspecification') and (iter_limit != 1):
-            raise ValueError(" weight_type: OneStepMisspecification must set iter_limit=1")
-        elif (cov_type == 'OneStepMisspecification') and (iter_limit != 1):
+        if (self._weight_type == "OneStepMisspecification") and (iter_limit != 1):
+            raise ValueError(
+                " weight_type: OneStepMisspecification must set iter_limit=1"
+            )
+        elif (cov_type == "OneStepMisspecification") and (iter_limit != 1):
             raise ValueError(" cov_type: OneStepMisspecification must set iter_limit=1")
-        if (iter_limit != 1) and (initial_weight is None) and \
-                (self._weight_type == 'OneStepMisspecification'):
+        if (
+            (iter_limit != 1)
+            and (initial_weight is None)
+            and (self._weight_type == "OneStepMisspecification")
+        ):
             wmat = inv(weight_matrix(wx, wz, zeros((nobs, 1))))
-        elif (initial_weight is None) and (self._weight_type == 'Misspecification'):
+        elif (initial_weight is None) and (self._weight_type == "Misspecification"):
             wmat = inv(wz.T @ wz)
         else:
             wmat = inv(wz.T @ wz / nobs) if initial_weight is None else initial_weight
@@ -1281,7 +1263,7 @@ class IVGMM(_IVGMMBase):
             iters += 1
 
         cov_config["debiased"] = debiased
-        if cov_type == 'Misspecification':
+        if cov_type == "Misspecification":
             cov_estimator = IVGMMCovariance(
                 wx, wy, wz, params, inv(wmat), cov_type, **cov_config
             )

--- a/linearmodels/iv/model.py
+++ b/linearmodels/iv/model.py
@@ -53,7 +53,6 @@ from numpy import (
     ones,
     sqrt,
     zeros,
-    sum,
     unique,
     diagflat,
 )
@@ -116,6 +115,7 @@ WEIGHT_MATRICES = {
 
 
 class _IVModelBase(object):
+
     r"""
     Limited information ML and k-class estimation of IV models
 
@@ -321,12 +321,12 @@ class _IVModelBase(object):
 
     @property
     def formula(self) -> str:
-        """Formula used to create the model"""
+        """Formula used to create the model."""
         return self._formula
 
     @formula.setter
     def formula(self, value: str) -> None:
-        """Formula used to create the model"""
+        """Formula used to create the model."""
         self._formula = value
 
     def _validate_inputs(self) -> None:
@@ -404,17 +404,17 @@ class _IVModelBase(object):
 
     @property
     def has_constant(self) -> bool:
-        """Flag indicating the model includes a constant or equivalent"""
+        """Flag indicating the model includes a constant or equivalent."""
         return self._has_constant
 
     @property
     def isnull(self) -> BoolArray:
-        """Locations of observations with missing values"""
+        """Locations of observations with missing values."""
         return self._drop_locs
 
     @property
     def notnull(self) -> BoolArray:
-        """Locations of observations included in estimation"""
+        """Locations of observations included in estimation."""
         return cast(BoolArray, logical_not(self._drop_locs))
 
     def _f_statistic(
@@ -998,7 +998,7 @@ class _IVGMMBase(_IVModelBase):
     def _gmm_post_estimation(
             self, params: Float64Array, weight_mat: Float64Array, iters: int
     ) -> Dict[str, Any]:
-        """GMM-specific post-estimation results"""
+        """GMM-specific post-estimation results."""
         instr = self._instr_columns
         gmm_specific = {
             "weight_mat": DataFrame(weight_mat, columns=instr, index=instr),
@@ -1013,7 +1013,7 @@ class _IVGMMBase(_IVModelBase):
     def _j_statistic(
             self, params: Float64Array, weight_mat: Float64Array
     ) -> WaldTestStatistic:
-        """J stat and test"""
+        """J stat and test."""
         y, x, z = self._wy, self._wx, self._wz
         nobs, nvar, ninstr = y.shape[0], x.shape[1], z.shape[1]
         eps = y - x @ params

--- a/linearmodels/iv/model.py
+++ b/linearmodels/iv/model.py
@@ -1,6 +1,4 @@
-"""
-Instrumental variable estimators
-"""
+"""Instrumental variable estimators."""
 from __future__ import annotations
 
 from typing import Any, Dict, Optional, Tuple, Type, TypeVar, Union, cast


### PR DESCRIPTION
The zip is the testcode with python(linearmodel ivgmm) and MATLAB with One-Step and Iter GMM
[test.zip](https://github.com/bashtage/linearmodels/files/8839484/test.zip)
Improved the code quality of three documents according to Codacy
![image](https://user-images.githubusercontent.com/29805242/172039917-34c24365-335e-45ab-b026-8277c645a2db.png)
Fix the problem with code coverage ration and PEP8 issues I may need code checking.