### PR TITLE
Multiway clustering for PanelOLS

### DIFF
--- a/linearmodels/panel/covariance.py
+++ b/linearmodels/panel/covariance.py
@@ -234,7 +234,7 @@ class ClusteredCovariance(HomoskedasticCovariance):
         columns in x, e.g., fixed effects.  Covariance estimators are always
         adjusted for extra_df irrespective of the setting of debiased
     clusters : ndarray
-        nobs by 1 or nobs by 2 array of cluster group ids
+        nobs by 1, nobs by 2 or by n array of cluster group ids
     group_debias : bool
         Flag indicating whether to apply small-number of groups adjustment.
 

--- a/linearmodels/shared/covariance.py
+++ b/linearmodels/shared/covariance.py
@@ -57,7 +57,7 @@ def cluster_union(clusters: IntArray) -> IntArray:
     Parameters
     ----------
     clusters : ndarray
-        A nobs by 2 array of integer values of cluster group membership.
+        A nobs by d (>=2) array of integer values of cluster group membership.
 
     Returns
     -------
@@ -143,6 +143,29 @@ def cov_kernel(z: Float64Array, w: Float64Array) -> Float64Array:
 def multi_way_cluster_iter(
     clusters: Float64Array, xe: Float64Array, group_debias: bool = True
 ):
+    """
+    Multi-way clustering
+
+    Sums cluster covariances with an odd number of cluster dimensions,
+    subtracts those with an eve number of cluster dimensions. Whereas
+    cluster covariances with a number of cluster dimensions greater
+    than 1 are computed using the group formed from the
+    intersection of the n dimensions.
+
+    Parameters
+    ----------
+    clusters : ndarray
+        nobs by d (where d is the number of cluster dimensions)
+    xe : ndarray
+        nobs by k
+    group_debias: bool
+        Flag indicating whether to apply small-number of groups adjustment.
+
+    Returns
+    -------
+    ndarray
+       k by k
+    """
     clus_adj = 1
 
     xeex = {}
@@ -185,6 +208,21 @@ def multi_way_cluster_iter(
 
 
 def cgm_vcov_fix(vcov: Float64Array, toll: float = 1e-10):
+    """
+    VCOV fix à la Cameron, Gelbach & Miller 2011
+
+    Parameters
+    ----------
+    vcov: ndarray
+        k by k variance covariance matrix
+    toll: float
+        toll to set on eig values
+
+    Returns
+    -------
+    ndarray
+       k by k cluster covariance adjusted
+    """
     from warnings import warn
 
     if npany(diag(vcov) < 0):
@@ -193,7 +231,7 @@ def cgm_vcov_fix(vcov: Float64Array, toll: float = 1e-10):
 
         warn(
             "Non-positive semi-definite VCOV matrix; adjusted "
-            "a la Cameron, Gelbach & Miller 2011",
+            "à la Cameron, Gelbach & Miller 2011",
             VCOVWarning,
         )
 

--- a/linearmodels/shared/exceptions.py
+++ b/linearmodels/shared/exceptions.py
@@ -29,6 +29,10 @@ class IndexWarning(Warning):
     pass
 
 
+class VCOVWarning(Warning):
+    pass
+
+
 def missing_warning(missing: BoolArray, stacklevel: int = 4) -> None:
     """Utility function to perform missing value check and warning"""
     if not np.any(missing):
@@ -49,6 +53,7 @@ __all__ = [
     "MemoryWarning",
     "MissingValueWarning",
     "SingletonWarning",
+    "VCOVWarning",
     "missing_warning",
     "missing_value_warning_msg",
 ]

--- a/linearmodels/system/covariance.py
+++ b/linearmodels/system/covariance.py
@@ -7,8 +7,7 @@ from numpy.linalg import inv
 
 from linearmodels.asset_pricing.covariance import _HACMixin
 from linearmodels.iv.covariance import cov_cluster
-from linearmodels.panel.covariance import cluster_union
-from linearmodels.shared.covariance import group_debias_coefficient
+from linearmodels.shared.covariance import cluster_union, group_debias_coefficient
 from linearmodels.shared.utility import AttrDict
 from linearmodels.system._utility import (
     LinearConstraint,

--- a/linearmodels/tests/panel/test_panel_covariance.py
+++ b/linearmodels/tests/panel/test_panel_covariance.py
@@ -190,19 +190,19 @@ def test_clustered_covariance_smoke(panel_data) -> None:
     ).cov
     assert cov.shape == (panel_data.k, panel_data.k)
 
+    cov = ClusteredCovariance(
+        panel_data.y,
+        panel_data.x,
+        panel_data.params,
+        panel_data.entity_ids,
+        panel_data.time_ids,
+        extra_df=0,
+        clusters=panel_data.cluster5,
+    ).cov
+    assert cov.shape == (panel_data.k, panel_data.k)
+
 
 def test_clustered_covariance_error(panel_data) -> None:
-    with pytest.raises(ValueError):
-        ClusteredCovariance(
-            panel_data.y,
-            panel_data.x,
-            panel_data.params,
-            panel_data.entity_ids,
-            panel_data.time_ids,
-            extra_df=0,
-            clusters=panel_data.cluster5,
-        )
-
     with pytest.raises(ValueError):
         ClusteredCovariance(
             panel_data.y,

--- a/linearmodels/tests/panel/test_panel_ols.py
+++ b/linearmodels/tests/panel/test_panel_ols.py
@@ -1078,18 +1078,15 @@ def test_cluster_smoke(data):
     mod.fit(cov_type="clustered", clusters=c2, debiased=False)
     mod.fit(cov_type="clustered", cluster_entity=True, clusters=c1, debiased=False)
     mod.fit(cov_type="clustered", cluster_time=True, clusters=c1, debiased=False)
-    with pytest.raises(ValueError):
-        mod.fit(cov_type="clustered", cluster_time=True, clusters=c2, debiased=False)
-    with pytest.raises(ValueError):
-        mod.fit(cov_type="clustered", cluster_entity=True, clusters=c2, debiased=False)
-    with pytest.raises(ValueError):
-        mod.fit(
-            cov_type="clustered",
-            cluster_entity=True,
-            cluster_time=True,
-            clusters=c1,
-            debiased=False,
-        )
+    mod.fit(cov_type="clustered", cluster_time=True, clusters=c2, debiased=False)
+    mod.fit(cov_type="clustered", cluster_entity=True, clusters=c2, debiased=False)
+    mod.fit(
+        cov_type="clustered",
+        cluster_entity=True,
+        cluster_time=True,
+        clusters=c1,
+        debiased=False,
+    )
     with pytest.raises(ValueError):
         clusters = c1.dataframe.iloc[: c1.dataframe.shape[0] // 2]
         mod.fit(cov_type="clustered", clusters=clusters, debiased=False)


### PR DESCRIPTION
This PR modifies the existing cov method in the panel ClusteredCovariance class and adds a call to a function that allows for multiway clustering. Cases in which the vcov matrix has negative values in the diagonal elements are fixed à la Cameron, Gelbach & Miller 2011.

The main function added to allow for multiway clustering (multi_way_cluster_iter) is placed under the shared folder and can be later reused by other objects such as AbsorbingLS.

Tests are modified accordingly
Related documentation is modified in the existing code and added