### PR TITLE
MAINT: Update License Classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ def run_setup(binary: bool = True) -> None:
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
-            "License :: OSI Approved",
+            "License :: OSI Approved :: University of Illinois/NCSA Open Source License",
             "Operating System :: MacOS :: MacOS X",
             "Operating System :: Microsoft :: Windows",
             "Operating System :: POSIX",


### PR DESCRIPTION
Updates license to match appropriate [PyPI project classifier](https://pypi.org/classifiers/)

The reason that it is very important for this information to be present is that in an enterprise environment, security tools like [Sonatype Nexus IQ](https://help.sonatype.com/iqserver) are used to manage open source software risk. Nexus IQ specifically can be configured to [classify packages according to their license](https://help.sonatype.com/iqserver/managing/policy-management/license-threat-groups). This allows companies to control which licenses are used internally to prevent accidental use of an overly restrictive license.

If no license, or incorrect license is included in the PyPI classifiers, then automated tools may assume that no license exists and the software cannot be used:


![image](https://github.com/bashtage/linearmodels/assets/7910938/651e01cf-3e0a-466d-8ba1-4ccc69775b88)


Adding this license information will increase the availability of linearmodels within enterprise environments.