### PR TITLE
ENH: Build against NumPy 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ regression. Currently only the single variable IV estimators are polished.
 
 -   Python 3.9+
 -   NumPy (1.22+)
--   SciPy (1.5+)
--   pandas (1.3+)
+-   SciPy (1.8+)
+-   pandas (1.4+)
 -   statsmodels (0.12+)
--   formulaic (0.6.5+)
+-   formulaic (1.0.0+)
 -   xarray (0.16+, optional)
--   Cython (0.29.37+, optional)
+-   Cython (3.0.10+, optional)
 
 
 ### Testing

--- a/ci/azure_template_posix.yml
+++ b/ci/azure_template_posix.yml
@@ -18,8 +18,8 @@ jobs:
     matrix:
       python39_minimums:
         python.version: '3.9'
-        NUMPY: 1.22.0
-        SCIPY: 1.5.0
+        NUMPY: 1.22.3
+        SCIPY: 1.8.0
         PANDAS: 1.3.0
         STATSMODELS: 0.12.0
         XARRAY: 0.21.0
@@ -28,7 +28,7 @@ jobs:
       python39_mid:
         python.version: '3.9'
         NUMPY: 1.23.0
-        SCIPY: 1.6.0
+        SCIPY: 1.9.0
         PANDAS: 1.4.0
         STATSMODELS: 0.13.0
         XARRAY: 2022.6.0
@@ -38,7 +38,7 @@ jobs:
       python39_recent:
         python.version: '3.9'
         NUMPY: 1.24.0
-        SCIPY: 1.7.0
+        SCIPY: 1.10.0
         PANDAS: 1.5.0
         STATSMODELS: 0.13.0
         XARRAY: 2022.12.0
@@ -50,7 +50,7 @@ jobs:
       python310_recent:
         python.version: '3.10'
         NUMPY: 1.24.0
-        SCIPY: 1.9.0
+        SCIPY: 1.12.0
         PANDAS: 2.0.0
         STATSMODELS: 0.14.0
         XARRAY: 2023.4.0

--- a/ci/install-posix.sh
+++ b/ci/install-posix.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CMD="python -m pip install setuptools_scm[toml]>=7 formulaic numpy"
+CMD="python -m pip install setuptools_scm[toml]>=8 formulaic numpy"
 if [[ -n ${NUMPY} ]]; then CMD="$CMD~=${NUMPY}"; fi;
 CMD="$CMD scipy"
 if [[ -n ${SCIPY} ]]; then CMD="$CMD~=${SCIPY}"; fi;

--- a/doc/source/changes/5.0.rst
+++ b/doc/source/changes/5.0.rst
@@ -1,3 +1,8 @@
+Verison 5.5
+----------
+- Full compatibility with NumPy 2, and NumPy 1.22.3+
+- Compatibility with future pandas releases (3.0.0)
+
 Verison 5.4
 ----------
 - Compatibility with NumPy 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,15 +2,14 @@
 requires = [
   "setuptools>=61",
   "wheel",
-  "setuptools_scm[toml]>=7,<8",
-  "oldest-supported-numpy",
-  "numpy; python_version>='3.13'",
-  "cython>=0.29.34"
+  "setuptools_scm[toml]>=8,<9",
+  "numpy>=2.0.0rc1,<3",
+  "cython>=3.0.10,<4"
 ]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311', 'py312']
 exclude = '''
 (
     \.egg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-numpy>=1.22.0
-pandas>=1.3.0
-scipy>=1.5.0
+numpy>=1.22.3,<3
+pandas>=1.4.0
+scipy>=1.8.0
 statsmodels>=0.12.0
 mypy_extensions>=0.4
-Cython>=0.29.37
+Cython>=3.0.10
 pyhdfe>=0.1
-formulaic>=0.6.5
+formulaic>=1.0.0
 # versioning
 setuptools_scm[toml]>=8.0.0,<9.0.0
 


### PR DESCRIPTION
Bump minimums for NumPy 2 build
Require NumPy 2