### PR TITLE
DOC: Fix typos in docstrings and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ estimating asset prices:
     -   Pooled regression for panel data
     -   Fama-MacBeth estimation of panel models
 
--   **High-dimensional Regresssion**:
+-   **High-dimensional Regression**:
     -   Absorbing Least Squares
 
 -   **Instrumental Variable estimators**

--- a/doc/source/changes/4.0.rst
+++ b/doc/source/changes/4.0.rst
@@ -19,7 +19,7 @@ Version 4.31
 
 Version 4.30
 ~~~~~~~~~~~~
-* Improved compatability with unreleased versions of NumPy and pandas.
+* Improved compatibility with unreleased versions of NumPy and pandas.
 
 
 Version 4.29
@@ -28,11 +28,11 @@ Version 4.29
   :class:`~linearmodels.panel.results.FamaMacBethResults` as
   :meth:`~linearmodels.panel.results.FamaMacBethResults.avg_rsquared` and
   :meth:`~linearmodels.panel.results.FamaMacBethResults.avg_adj_rsquared`.
-* Initial compatability with pandas 2.0 Copy-on-Write feature.
+* Initial compatibility with pandas 2.0 Copy-on-Write feature.
 
 Version 4.28
 ~~~~~~~~~~~~
-* Expanded compatability for formulaic from 0.3.2 to 0.5.2
+* Expanded compatibility for formulaic from 0.3.2 to 0.5.2
 * Fixed a few issues related to pandas 2.0
 * Added tests and wheel support for Python 3.11
 
@@ -161,8 +161,8 @@ Version 4.12
 ~~~~~~~~~~~~
 * Added an option to drop singleton observations in
   :class:`~linearmodels.panel.model.PanelOLS` by setting the keyword argument
-  ``singletons-False``. When ``False``, singelton observations are dropped
-  before the model is fit, so the the result is *as-if* the observations were
+  ``singletons-False``. When ``False``, singleton observations are dropped
+  before the model is fit, so the result is *as-if* the observations were
   never in ``exog`` or ``dependent``.
 * Added a method to construct the 2-core graph for 2-way effects models, which
   allows singleton observations with no effect on estimated slopes to be

--- a/doc/source/changes/5.0.rst
+++ b/doc/source/changes/5.0.rst
@@ -1,9 +1,9 @@
-Verison 5.5
+Version 5.5
 -----------
 - Full compatibility with NumPy 2, and NumPy 1.22.3+
 - Compatibility with future pandas releases (3.0.0)
 
-Verison 5.4
+Version 5.4
 -----------
 - Compatibility with NumPy 2
 - Compatibility with recent pandas releases

--- a/linearmodels/asset_pricing/covariance.py
+++ b/linearmodels/asset_pricing/covariance.py
@@ -93,7 +93,7 @@ class HeteroskedasticCovariance:
     debiased : bool
         Flag indicating to use a debiased estimator. Default is False.
     df : int
-        Degree of freedom value ot use if debiasing. Default is 0.
+        Degree of freedom value to use if debiasing. Default is 0.
     """
 
     def __init__(
@@ -220,7 +220,7 @@ class KernelCovariance(HeteroskedasticCovariance, _HACMixin):
     debiased : bool
         Flag indicating to use a debiased estimator.
     df : int
-        Degree of freedom value ot use if debiasing.
+        Degree of freedom value to use if debiasing.
 
     See Also
     --------

--- a/linearmodels/iv/model.py
+++ b/linearmodels/iv/model.py
@@ -1684,7 +1684,7 @@ class _OLS(IVLIML):
     Computes OLS estimates when required
 
     Private class used when model reduces to OLS. Should use the statsmodels
-    version when neeeding a supported public API.
+    version when needing a supported public API.
 
     Parameters
     ----------

--- a/linearmodels/panel/data.py
+++ b/linearmodels/panel/data.py
@@ -151,7 +151,7 @@ class PanelData:
     can be treated as-if being (1, nobs, nentity).
 
     If the 2-d input is a pandas DataFrame with a 2-level MultiIndex then the
-    input is treated differently.  Index level 0 is assumed ot be entity.
+    input is treated differently.  Index level 0 is assumed to be entity.
     Index level 1 is time.  The columns are the variables.  MultiIndex Series
     are also accepted and treated as single column MultiIndex DataFrames.
 


### PR DESCRIPTION
DOC: Fix typos in docstrings and documentation

Ran codespell over the package and docs and fixed the genuine spelling
mistakes (skipped the false positives like `coo`, the `te`/`oe` format
keys, and `pres`).

Docstrings (these render in the API docs):
- `linearmodels/asset_pricing/covariance.py` - "Degree of freedom value
  ot use" -> "to use" (HeteroskedasticCovariance and KernelCovariance).
- `linearmodels/iv/model.py` - `_OLS` docstring "when neeeding a supported
  public API" -> "needing".
- `linearmodels/panel/data.py` - "Index level 0 is assumed ot be entity"
  -> "to be entity".

Docs / README:
- `README.md` - "High-dimensional Regresssion" -> "Regression".
- `doc/source/changes/4.0.rst` - "compatability" -> "compatibility" (x3),
  "singelton" -> "singleton", and a duplicated "the the" -> "the".
- `doc/source/changes/5.0.rst` - "Verison" -> "Version" (x2) in the
  section headings (same length, so the underlines stay valid).

Text-only; no code changes. The three touched modules still byte-compile.
