### PR TITLE
DOC: Fix Driscoll-Kraay covariance index

### DIFF
--- a/doc/source/panel/mathematical-detail.lyx
+++ b/doc/source/panel/mathematical-detail.lyx
@@ -834,7 +834,7 @@ n_{obs}/(n_{obs}-k)\Sigma_{XX}^{-1}\hat{S}_{HAC}\Sigma_{XX}^{-1}
 where 
 \begin_inset Formula 
 \begin{align*}
-\hat{S}_{HAC} & =\hat{\Gamma}_{0}+\sum_{i=1}^{bw}K(i,bw)(\hat{\Gamma}_{1}+\hat{\Gamma}_{1}^{\prime})\\
+\hat{S}_{HAC} & =\hat{\Gamma}_{0}+\sum_{i=1}^{bw}K(i,bw)(\hat{\Gamma}_{i}+\hat{\Gamma}_{i}^{\prime})\\
 \hat{\Gamma}_{i} & =\sum_{t=i+1}^{T}\xi_{t}^{\prime}\xi_{t}\\
 \xi_{t} & =\sum_{i=1}^{n_{t}}\hat{\epsilon}_{it}x_{it}
 \end{align*}

--- a/doc/source/panel/mathematical-detail.txt
+++ b/doc/source/panel/mathematical-detail.txt
@@ -235,7 +235,7 @@ where
 .. math::
 
    \begin{aligned}
-   \hat{S}_{HAC} & =\hat{\Gamma}_{0}+\sum_{i=1}^{bw}K(i,bw)(\hat{\Gamma}_{1}+\hat{\Gamma}_{1}^{\prime})\\
+   \hat{S}_{HAC} & =\hat{\Gamma}_{0}+\sum_{i=1}^{bw}K(i,bw)(\hat{\Gamma}_{i}+\hat{\Gamma}_{i}^{\prime})\\
    \hat{\Gamma}_{i} & =\sum_{t=i+1}^{T}\xi_{t}^{\prime}\xi_{t}\\
    \xi_{t} & =\sum_{i=1}^{n_{t}}\hat{\epsilon}_{it}x_{it}\end{aligned}
 


### PR DESCRIPTION
## Summary
- replace the fixed Gamma_1 term in the Driscoll-Kraay HAC sum with the indexed Gamma_i term
- keep the LyX source and included text representation aligned

Closes #583

## Validation
- the changed math directive parses with Docutils
- git diff --check passes
- the full Sphinx build could not start locally because the editable native package build requires the Visual Studio toolchain